### PR TITLE
Fixed Cannot read property 'toLocaleLowerCase' of undefined log entries.

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -175,7 +175,7 @@ export class Zigbee2mqttPlatform implements DynamicPlatformPlugin {
 
       for (const devConfig of this.config.devices) {
         try {
-          if (identifiers.includes(devConfig.id.toLocaleLowerCase())) {
+          if (devConfig !== undefined && devConfig.id !== undefined && identifiers.includes(devConfig.id.toLocaleLowerCase())) {
             return devConfig;
           }
         } catch(error) {
@@ -199,7 +199,7 @@ export class Zigbee2mqttPlatform implements DynamicPlatformPlugin {
   private addAccessory(accessory: PlatformAccessory) {
     if (this.isDeviceExcluded(accessory.context.device)) {
       this.log.warn(`Excluded device found on startup: ${accessory.context.device.friendly_name} (${accessory.context.device.ieeeAddr}).`);
-      process.nextTick(() => {  
+      process.nextTick(() => {
         try {
           this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
         } catch (error) {


### PR DESCRIPTION
After integrating with my ZigBee devices I experienced many error log entries due to undefined property. I don't think it is intentional to see those message.

<img width="1100" alt="Screenshot 2020-10-16 at 23 57 37" src="https://user-images.githubusercontent.com/7303508/96312177-60398880-100b-11eb-94e0-8975b3d4feab.png">
