### PR TITLE
Adds option to exclude devices

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -137,6 +137,16 @@
                   }
                }
             }
+         },
+         "excluded_devices": {
+            "title": "Excluded devices",
+            "type": "array",
+            "required": false,
+            "items": {
+               "title": "Friendly name",
+               "type": "string",
+               "minLength": 1
+            }
          }
       }
    }

--- a/src/configModels.ts
+++ b/src/configModels.ts
@@ -3,6 +3,7 @@ import { PlatformConfig, Logger } from 'homebridge';
 export interface PluginConfiguration extends PlatformConfig {
    mqtt: MqttConfiguration;
    devices?: DeviceConfiguration[];
+   excluded_devices?: string[];
 }
 export const isPluginConfiguration = (x: PlatformConfig, logger: Logger | undefined = undefined): x is PluginConfiguration => {
   if (x.mqtt === undefined || !isMqttConfiguration(x.mqtt)) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -224,11 +224,16 @@ export class Zigbee2mqttPlatform implements DynamicPlatformPlugin {
 
   private isDeviceExcluded(device: DeviceListEntry | string): boolean {
     const additionalConfig = this.getAdditionalConfigForDevice(device);
-    if (additionalConfig?.exclude) {
-      this.log.debug(`Device is excluded: ${additionalConfig.id}`);
-      return true;
+    let excluded = additionalConfig?.exclude || false;
+    if (typeof device !== 'string') {
+      excluded = (this.config?.excluded_devices || []).includes(device.friendly_name);
     }
-    return false;
+
+    if (excluded) {
+      this.log.debug(`Device is excluded: ${additionalConfig?.id}`);
+    }
+
+    return excluded;
   }
 
   private addAccessory(accessory: PlatformAccessory) {


### PR DESCRIPTION
This pull request adds a new configuration option (`excluded_devices`). Instead of needing an array of object, it's simply an array of "Friendly name". Still keeping the old functionality.