### PR TITLE
Specify minValue on CurrentTemperature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 Since version 1.0.0, we try to follow the [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard.
 
 ## [Unreleased]
+### Fixed
+
+- Temperature sensors showed up as unavailable if the temperature dropped below 0°C, because the default range in HomeKit is 0 to 100°C (see [#49](https://github.com/itavero/homebridge-z2m/pull/49)).
 
 ## [1.1.0-beta.3] - 2021-01-30
 ### Fixed

--- a/src/converters/basic_sensors.ts
+++ b/src/converters/basic_sensors.ts
@@ -181,8 +181,11 @@ class TemperatureSensorHandler extends BasicSensorHandler {
   constructor(expose: ExposesEntryWithProperty, allExposes: ExposesEntryWithBinaryProperty[], accessory: BasicAccessory) {
     super(accessory, expose, allExposes, TemperatureSensorHandler.generateIdentifier, (n, t) => new hap.Service.TemperatureSensor(n, t));
     accessory.log.debug(`Configuring TemperatureSensor for ${this.serviceName}`);
-
-    getOrAddCharacteristic(this.service, hap.Characteristic.CurrentTemperature);
+    getOrAddCharacteristic(this.service, hap.Characteristic.CurrentTemperature)
+      .setProps({
+        minValue: -100,
+        maxValue: 100,
+      });
     this.monitors.push(new PassthroughCharacteristicMonitor(expose.property, this.service, hap.Characteristic.CurrentTemperature));
   }
 


### PR DESCRIPTION
I'm using an Aqara temperature and humidity sensor outside and notice that when the temperature drops bellow 0 degrees the Home app reports the device as not responding (only the temperature). Not sure why [`Characteristic.CurrentTemperature`](https://developers.homebridge.io/#/characteristic/CurrentTemperature) has a min. value of 0 and if there's any downsides of settings this to something other than the defaults. 