### PR TITLE
Use Battery instead of the deprecated BatteryService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 Since version 1.0.0, we try to follow the [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard.
 
 ## [Unreleased]
+### Changed
+
+- Use `Service.Battery` instead of `Service.BatteryService` which is deprecated in Homebridge 1.3.0. This change will require users to have a recent version of Homebridge installed.
 
 ## [1.1.1] - 2021-02-09
 ### Fixed

--- a/src/converters/battery.ts
+++ b/src/converters/battery.ts
@@ -58,7 +58,7 @@ class BatteryHandler implements ServiceHandler {
     }
 
     accessory.log.debug(`Configuring Battery Service for ${serviceName}`);
-    const service = accessory.getOrAddService(new hap.Service.BatteryService(serviceName, endpoint));
+    const service = accessory.getOrAddService(new hap.Service.Battery(serviceName, endpoint));
     getOrAddCharacteristic(service, hap.Characteristic.BatteryLevel);
     getOrAddCharacteristic(service, hap.Characteristic.StatusLowBattery);
     getOrAddCharacteristic(service, hap.Characteristic.ChargingState);
@@ -121,7 +121,7 @@ class BatteryHandler implements ServiceHandler {
   }
 
   static generateIdentifier(endpoint: string | undefined) {
-    let identifier = hap.Service.BatteryService.UUID;
+    let identifier = hap.Service.Battery.UUID;
     if (endpoint !== undefined) {
       identifier += '_' + endpoint.trim();
     }

--- a/src/docgen/docgen.ts
+++ b/src/docgen/docgen.ts
@@ -70,7 +70,7 @@ const serviceNameMapping = new Map<string, ServiceInfo>([
   addServiceMapping(hapNodeJs.Service.Lightbulb, 'light.md'),
   addServiceMapping(hapNodeJs.Service.StatelessProgrammableSwitch, 'action.md'),
   addServiceMapping(hapNodeJs.Service.WindowCovering, 'cover.md'),
-  addServiceMapping(hapNodeJs.Service.BatteryService, 'battery.md'),
+  addServiceMapping(hapNodeJs.Service.Battery, 'battery.md'),
   addServiceMapping(hapNodeJs.Service.LockMechanism, 'lock.md'),
   addServiceMapping(hapNodeJs.Service.Switch, 'switch.md'),
   addServiceMapping(hapNodeJs.Service.Thermostat, 'climate.md'),


### PR DESCRIPTION
Not sure if I'll merge this already, as this change will require users to use a very recent version of Homebridge.