### PR TITLE
Skip device update if payload is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 Since version 1.0.0, we try to follow the [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard.
 
 ## [Unreleased]
+### Changed
+
+- Improved logging when handling a (potential) device update fails. (PR [#78](https://github.com/itavero/homebridge-z2m/pull/78))
+- Ignore empty device updates. (PR [#78](https://github.com/itavero/homebridge-z2m/pull/78))
 
 ## [1.1.1] - 2021-02-09
 ### Fixed

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -171,7 +171,7 @@ export class Zigbee2mqttPlatform implements DynamicPlatformPlugin {
       } catch (Error) {
         this.log.error('Failed to process status update.');
         this.log.error(Error);
-        this.log.info(`Payload: ${statePayload}`);
+        this.log.error(`Payload: ${statePayload}`);
       }
     } else {
       this.log.debug(`Unhandled message on topic: ${topic}`);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -158,6 +158,11 @@ export class Zigbee2mqttPlatform implements DynamicPlatformPlugin {
   }
 
   private async handleDeviceUpdate(topic: string, statePayload: string) {
+    if (statePayload === '') {
+      this.log.debug('Ignore update, because payload is empty.', topic);
+      return;
+    }
+
     const accessory = this.accessories.find((acc) => acc.matchesIdentifier(topic));
     if (accessory) {
       try {
@@ -166,6 +171,7 @@ export class Zigbee2mqttPlatform implements DynamicPlatformPlugin {
       } catch (Error) {
         this.log.error('Failed to process status update.');
         this.log.error(Error);
+        this.log.info(`Payload: ${statePayload}`);
       }
     } else {
       this.log.debug(`Unhandled message on topic: ${topic}`);


### PR DESCRIPTION
When renaming a device zigbee2mqtt sends a message with an empty payload to the old device topic (see https://github.com/Koenkk/zigbee2mqtt/blob/6484feecb7c4727c0623a8a6264bac8b3403bbb3/lib/extension/bridge.js#L390) and this breaks the JSON parsing resulting in an error in the logs. 

This PR checks that the payload is not empty before trying to parse it as JSON. It also adds the raw payload to the logs if the JSON parsing fails to any other reason so that it's easier to debug this issue in the future.

---

BTW thanks for this great library! Just started using it and it's so useful.