### PR TITLE
Add option to force QoS level to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Since version 1.0.0, we try to follow the [Semantic Versioning](https://semver.o
 ### Added
 
 - Default device options can now be set using the `defaults` key in the plugin configuration.
+- Add plugin option `mqtt.disable_qos` to force the QoS Level to `0` (best effort) for published messages. This might be needed
+  when using certain (cloud) MQTT brokers. (see [#150](https://github.com/itavero/homebridge-z2m/pull/150))
 
 ## [1.1.3] - 2021-03-08
 ### Fixed

--- a/config.schema.json
+++ b/config.schema.json
@@ -75,6 +75,12 @@
                   "minimum": 3,
                   "maximum": 5,
                   "required": false
+               },
+               "disable_qos": {
+                  "title": "Disable QoS",
+                  "type": "boolean",
+                  "default": false,
+                  "required": false
                }
             }
          },

--- a/docs/config.md
+++ b/docs/config.md
@@ -66,6 +66,10 @@ Within the `mqtt` object, you can add pretty much all the configuration options 
 * `keepalive`
 * `version`
 
+### Disable MQTT QoS
+Some MQTT Broker doesn't support QoS Level. The plugin option `disable_qos` allow forcing QoS level to 0. If `disable_qos` is empty or equal to false, default QoS level is use.
+You don't have to set `disable_qos` option, if you use local mqtt broker like mosquitto.
+
 ## Devices
 Within the `devices` array, you can set options for specific devices, based on their IEEE addresses (`0x1234567890abcdef`) or the `friendly_name`.
 This identifier should be put in the `id` property.

--- a/docs/config.md
+++ b/docs/config.md
@@ -66,9 +66,9 @@ Within the `mqtt` object, you can add pretty much all the configuration options 
 * `keepalive`
 * `version`
 
-### Disable MQTT QoS
-Some MQTT Broker doesn't support QoS Level. The plugin option `disable_qos` allow forcing QoS level to 0. If `disable_qos` is empty or equal to false, default QoS level is use.
-You don't have to set `disable_qos` option, if you use local mqtt broker like mosquitto.
+### Disable QoS for published MQTT messages
+Some MQTT brokers do not have support for QoS. If the QoS Levels sent by this plugin are leading to problems, you can force the plugin to disable this for all messages (i.e. set the QoS level to 0) by setting the `disable_qos` to `true`.
+By default, this option is set to `false`. Note: this option does **not** exist in Zigbee2MQTT itself.
 
 ## Devices
 Within the `devices` array, you can set options for specific devices, based on their IEEE addresses (`0x1234567890abcdef`) or the `friendly_name`.

--- a/src/configModels.ts
+++ b/src/configModels.ts
@@ -44,6 +44,7 @@ export interface MqttConfiguration extends Record<string, unknown> {
    reject_unauthorized?: boolean;
    keepalive?: number;
    version?: number;
+   disable_qos?: boolean;
 }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isMqttConfiguration = (x: any): x is MqttConfiguration => (

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -140,7 +140,6 @@ export class Zigbee2mqttAccessory implements BasicAccessory {
       for (const k of keys) {
         data[k] = 0;
       }
-
       // Publish using ieeeAddr, as that will never change and the friendly_name might.
       this.platform.publishMessage(`${this.accessory.context.device.ieee_address}/get`,
         JSON.stringify(data), { qos: this.getMqttQosLevel(1) });
@@ -199,8 +198,8 @@ export class Zigbee2mqttAccessory implements BasicAccessory {
   }
 
   private publishPendingSetData() {
-    const topic = `${this.accessory.context.device.ieee_address}/set`;
-    this.platform.publishMessage(topic, JSON.stringify(this.pendingPublishData), { qos: this.getMqttQosLevel(2) });
+    this.platform.publishMessage(`${this.accessory.context.device.ieee_address}/set`, JSON.stringify(this.pendingPublishData),
+      { qos: this.getMqttQosLevel(2) });
     this.publishIsScheduled = false;
     this.pendingPublishData = {};
   }
@@ -279,11 +278,11 @@ export class Zigbee2mqttAccessory implements BasicAccessory {
     }
   }
 
-  //Get QoS level, if disable_qos option is set QoS equal to 0 level (best effort)
   private getMqttQosLevel(defaultQoS: QoS): QoS {
-    let mqttQos: QoS;
-    this.platform.config?.mqtt.force_disable_retain ? mqttQos = 0 : mqttQos = defaultQoS;
-    return mqttQos;
+    if (this.platform.config?.mqtt.disable_qos) {
+      return 0;
+    }
+    return defaultQoS;
   }
 
   updateStates(state: Record<string, unknown>) {


### PR DESCRIPTION
Zigbee2mqtt provide option to send MQTT message with level 0 QoS. This option is useful to use shared public hub provider like AWS, Azure, Scaleway...

I add the same zigbee2mqtt option : **force_disable_retain**

if option is set to true, all message are publish with lower QoS level. Otherwise, the default plugin QoS is use like level 1 or 2