### PR TITLE
Fix onMessage payload format handling

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -182,10 +182,19 @@ export class Zigbee2mqttPlatform implements DynamicPlatformPlugin {
       return;
     }
 
-    const accessory = this.accessories.find((acc) => acc.matchesIdentifier(topic));
-    if (accessory) {
+    const paths = topic.split("/");
+    const deviceName = paths[0];
+    const updateType = paths.length === 2 ? "individual" : paths.length === 1 ? "json" : undefined;
+    
+    const accessory = this.accessories.find((acc) => acc.matchesIdentifier(deviceName));
+    if (accessory && updateType) {
       try {
-        const state = JSON.parse(statePayload);
+        let state: Record<string, unknown>;
+        if (updateType === "individual") {
+          state = {[paths[1]]: statePayload};
+        } else {
+          state = JSON.parse(statePayload);
+        }
         accessory.updateStates(state);
         this.log.debug(`Handled device update for ${topic}: ${statePayload}`);
       } catch (Error) {


### PR DESCRIPTION
All my devices are sending messages in next format:
`Handled device update for Conditioner/temperature: 21`
while this plugin waiting for:
`Handled device update for Conditioner: {"temperature": 21}`
PR fixes this issue.
P.S. Can you explain please why plugin is waiting for json answer?