### PR TITLE
Fixes typo related to predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Since version 1.0.0, we try to follow the [Semantic Versioning](https://semver.o
 
 ### Fixed
 
-- Typo causing same predicate to be used twice when checking for system_mode and running_state properties in climate converter.
+- Removed unnecessary code from climate service.
 
 ## [1.6.0] - 2021-08-24
 

--- a/src/converters/climate.ts
+++ b/src/converters/climate.ts
@@ -95,19 +95,7 @@ class ThermostatHandler implements ServiceHandler {
       return false;
     }
 
-    // If system_mode is present, running_state must also be present.
-    // If both are not present, we'll assume a Heat only device, which is always in heating mode.
-    let feature = e.features.find(ThermostatHandler.PREDICATE_TARGET_MODE);
-    const hasTargetMode = feature !== undefined && !accessory.isPropertyExcluded(feature.property);
-    feature = e.features.find(ThermostatHandler.PREDICATE_CURRENT_STATE);
-    const hasCurrentStateMode = feature !== undefined && !accessory.isPropertyExcluded(feature.property);
-    if (hasTargetMode || hasCurrentStateMode) {
-      if (!hasTargetMode || !hasCurrentStateMode) {
-        return false;
-      }
-    }
-
-    feature = e.features.find(ThermostatHandler.PREDICATE_LOCAL_TEMPERATURE);
+    let feature = e.features.find(ThermostatHandler.PREDICATE_LOCAL_TEMPERATURE);
     if (feature === undefined || accessory.isPropertyExcluded(feature.property)) {
       return false;
     }
@@ -149,6 +137,12 @@ class ThermostatHandler implements ServiceHandler {
       this.currentStateExpose = undefined;
     }
     if (this.targetModeExpose === undefined || this.currentStateExpose === undefined) {
+      if (this.targetModeExpose !== undefined) {
+        this.accessory.log.debug(`${accessory.displayName}: ignore ${this.targetModeExpose.property}; no current state exposed.`);
+      }
+      if (this.currentStateExpose !== undefined) {
+        this.accessory.log.debug(`${accessory.displayName}: ignore ${this.currentStateExpose.property}; no current state exposed.`);
+      }
       // If one of them is undefined, ignore the other one
       this.targetModeExpose = undefined;
       this.currentStateExpose = undefined;


### PR DESCRIPTION
The same predicate is used twice. However the code suggests that 2 differente predicates should be checked, namely PREDICATE_TARGET_MODE and PREDICATE_CURRENT_STATE