### PR TITLE
Fix cover not updating correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Since version 1.0.0, we try to follow the [Semantic Versioning](https://semver.o
 ### Fixed
 
 - Removed unnecessary code from climate service.
+- Polling mechanism for `cover` improved. In past releases the plugin could stop requesting updates too early. (see [#292](https://github.com/itavero/homebridge-z2m/pull/292))
 
 ## [1.6.0] - 2021-08-24
 

--- a/src/converters/cover.ts
+++ b/src/converters/cover.ts
@@ -132,9 +132,6 @@ class CoverHandler implements ServiceHandler {
     if (this.positionExpose.property in state) {
       const latestPosition = state[this.positionExpose.property] as number;
 
-      // Received an update: Reset flag
-      this.waitingForUpdate = false;
-
       // Ignore "first" update?
       const doIgnoreIfEqual = this.ignoreNextUpdateIfEqualToTarget;
       this.ignoreNextUpdateIfEqualToTarget = false;
@@ -142,6 +139,9 @@ class CoverHandler implements ServiceHandler {
         this.accessory.log.debug(`${this.accessory.displayName}: cover: ignore position update (equal to last target)`);
         return;
       }
+
+      // Received an update: Reset flag
+      this.waitingForUpdate = false;
 
       // If we cannot retrieve the position or we were not expecting an update,
       // always assume the state is "stopped".


### PR DESCRIPTION
When moving a cover we currently set waitingForUpdate = false BEFORE checking if the update is to be ignored. 

Since requestPositionUpdate has this:
```
    if (this.waitingForUpdate) {
      // Manually polling for the state, as we have not yet received an update.
      this.accessory.queueKeyForGetAction(this.positionExpose.property);
    }
```

This means if we ignore the first update from a cover; we stop requesting the cover for future updates in the timer and cannot update it's status. This tweak moves the waitingForUpdate reset until after the ignored check.