### PR TITLE
Add the option to expose Cover as a Window Accessory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Since version 1.0.0, we try to follow the [Semantic Versioning](https://semver.o
 
 ## [Unreleased]
 
+### Added
+
+- Further allow for alternative implementations. (see [#484](https://github.com/itavero/homebridge-z2m/issues/484))
+  - `cover` can be configured as a `cover` (default) or `window`
+
 ## [1.9.0] - 2022-06-29
 
 ### Added

--- a/docs/config.md
+++ b/docs/config.md
@@ -41,6 +41,14 @@ A possible configuration looks like this:
          }
       },
       {
+         "id": "0xabcd1234abcd1234",
+         "converters": {
+            "cover": {
+                  "type": "window"
+            }
+         }
+      },
+      {
          "id": "0x1234abcd1234abcd",
          "values": [
             {

--- a/docs/cover.md
+++ b/docs/cover.md
@@ -10,3 +10,21 @@ The table below shows how the different features within this `exposes` entry are
 The required [Position State](https://developers.homebridge.io/#/characteristic/PositionState) characteristic is set when the _Target Position_ is changed or when an `position` is received from MQTT (and the movement is assumed to be stopped).
 
 If the `position` can be _get_, the plugin will try to get frequent updates, after changing the _Target Position_. If the same position is reported twice, movement is assumed to be stopped.
+
+## Converter specific configuration (`cover`)
+
+- `type`: Allows you to use a different HomeKit service:
+  - `cover` (default): expose as a [Window Cover](https://developers.homebridge.io/#/service/WindowCovering)
+  - `window`: expose as a [Window](https://developers.homebridge.io/#/service/Window)
+
+```json
+{
+  "converters": {
+    "cover": {
+      "type": "window"
+    }
+  }
+}
+```
+
+Do note that if the cover is setup as a window the tilt controls (if present) will be ignored

--- a/src/converters/cover.ts
+++ b/src/converters/cover.ts
@@ -45,7 +45,7 @@ export class CoverCreator implements ServiceCreator {
       .forEach(e => this.createService(e as ExposesEntryWithFeatures, accessory, exposeAsWindow));
   }
 
-  private createService(expose: ExposesEntryWithFeatures, accessory: BasicAccessory, exposeAsWindow: Boolean): void {
+  private createService(expose: ExposesEntryWithFeatures, accessory: BasicAccessory, exposeAsWindow: boolean): void {
     try {
       const handler = new CoverHandler(expose, accessory, exposeAsWindow);
       accessory.registerServiceHandler(handler);
@@ -72,7 +72,7 @@ class CoverHandler implements ServiceHandler {
   private lastPositionSet = -1;
   private positionCurrent = -1;
 
-  constructor(expose: ExposesEntryWithFeatures, private readonly accessory: BasicAccessory, exposeAsWindow: Boolean) {
+  constructor(expose: ExposesEntryWithFeatures, private readonly accessory: BasicAccessory, exposeAsWindow: boolean) {
     const endpoint = expose.endpoint;
     const serviceTypeName = exposeAsWindow ? 'Window' : 'WindowCovering';
 
@@ -82,7 +82,7 @@ class CoverHandler implements ServiceHandler {
       && e.name === 'position' && exposesCanBeSet(e) && exposesIsPublished(e)) as ExposesEntryWithNumericRangeProperty;
 
     if(!exposeAsWindow) {
-        this.tiltExpose = expose.features.find(e => exposesHasNumericRangeProperty(e) && !accessory.isPropertyExcluded(e.property)
+      this.tiltExpose = expose.features.find(e => exposesHasNumericRangeProperty(e) && !accessory.isPropertyExcluded(e.property)
         && e.name === 'tilt' && exposesCanBeSet(e) && exposesIsPublished(e)) as ExposesEntryWithNumericRangeProperty | undefined;
     }
     
@@ -303,7 +303,7 @@ class CoverHandler implements ServiceHandler {
     }
   }
 
-  static generateIdentifier(exposeAsWindow: Boolean, endpoint: string | undefined) {
+  static generateIdentifier(exposeAsWindow: boolean, endpoint: string | undefined) {
     let identifier = exposeAsWindow ? hap.Service.Window.UUID : hap.Service.WindowCovering.UUID;
     if (endpoint !== undefined) {
       identifier += '_' + endpoint.trim();

--- a/test/cover.spec.ts
+++ b/test/cover.spec.ts
@@ -759,4 +759,228 @@ describe('Cover', () => {
     });
   });
 
+  describe('IKEA KADRILJ roller blind (As Window)', () => {
+    const deviceModelJson = `{
+      "date_code": "20190311",
+      "definition": {
+        "description": "KADRILJ roller blind",
+        "exposes": [
+          {
+            "features": [
+              {
+                "access": 7,
+                "name": "state",
+                "property": "state",
+                "type": "binary",
+                "value_off": "CLOSE",
+                "value_on": "OPEN"
+              },
+              {
+                "access": 7,
+                "description": "Position of this cover",
+                "name": "position",
+                "property": "position",
+                "type": "numeric",
+                "value_max": 100,
+                "value_min": 0
+              }
+            ],
+            "type": "cover"
+          },
+          {
+            "access": 1,
+            "description": "Remaining battery in %",
+            "name": "battery",
+            "property": "battery",
+            "type": "numeric",
+            "unit": "%",
+            "value_max": 100,
+            "value_min": 0
+          },
+          {
+            "access": 1,
+            "description": "Link quality (signal strength)",
+            "name": "linkquality",
+            "property": "linkquality",
+            "type": "numeric",
+            "unit": "lqi",
+            "value_max": 255,
+            "value_min": 0
+          }
+        ],
+        "model": "E1926",
+        "vendor": "IKEA"
+      },
+      "endpoints": {
+        "1": {
+          "bindings": [
+            {
+              "cluster": "genPowerCfg",
+              "target": {
+                "endpoint": 1,
+                "ieee_address": "0x00124b001caa69fb",
+                "type": "endpoint"
+              }
+            },
+            {
+              "cluster": "closuresWindowCovering",
+              "target": {
+                "endpoint": 1,
+                "ieee_address": "0x00124b001caa69fb",
+                "type": "endpoint"
+              }
+            }
+          ],
+          "clusters": {
+            "input": [
+              "genBasic",
+              "genPowerCfg",
+              "genIdentify",
+              "genGroups",
+              "genScenes",
+              "genPollCtrl",
+              "closuresWindowCovering",
+              "touchlink"
+            ],
+            "output": [
+              "genOta",
+              "touchlink"
+            ]
+          }
+        }
+      },
+      "friendly_name": "blinds_livingroom_side",
+      "ieee_address": "0x000d6ffffea9430d",
+      "interview_completed": true,
+      "interviewing": false,
+      "network_address": 13941,
+      "power_source": "Battery",
+      "software_build_id": "2.2.009",
+      "supported": true,
+      "type": "EndDevice"
+    }`;
+
+    // Shared "state"
+    let deviceExposes: ExposesEntry[] = [];
+    let harness: ServiceHandlersTestHarness;
+
+    beforeEach(() => {
+      // Only test service creation for first test case and reuse harness afterwards
+      if (deviceExposes.length === 0 && harness === undefined) {
+        // Test JSON Device List entry
+        const device = testJsonDeviceListEntry(deviceModelJson);
+        deviceExposes = device?.definition?.exposes ?? [];
+        expect(deviceExposes?.length).toBeGreaterThan(0);
+        const newHarness = new ServiceHandlersTestHarness();
+
+        // Check service creation
+        newHarness.addConverterConfiguration('cover', { type: 'window' });
+        const windowCovering = newHarness.getOrAddHandler(hap.Service.Window)
+          .addExpectedCharacteristic('position', hap.Characteristic.CurrentPosition, false)
+          .addExpectedCharacteristic('target_position', hap.Characteristic.TargetPosition, true, undefined, false)
+          .addExpectedCharacteristic('position_state', hap.Characteristic.PositionState, false, undefined, false);
+        newHarness.prepareCreationMocks();
+
+        const positionCharacteristicMock = windowCovering.getCharacteristicMock('position');
+        if (positionCharacteristicMock !== undefined) {
+          positionCharacteristicMock.props.minValue = 0;
+          positionCharacteristicMock.props.maxValue = 100;
+        }
+
+        const targetPositionCharacteristicMock = windowCovering.getCharacteristicMock('target_position');
+        if (targetPositionCharacteristicMock !== undefined) {
+          targetPositionCharacteristicMock.props.minValue = 0;
+          targetPositionCharacteristicMock.props.maxValue = 100;
+        }
+
+        newHarness.callCreators(deviceExposes);
+
+        newHarness.checkCreationExpectations();
+        newHarness.checkExpectedGetableKeys(['position']);
+        harness = newHarness;
+      }
+      harness?.clearMocks();
+    });
+
+    afterEach(() => {
+      verifyAllWhenMocksCalled();
+      resetAllWhenMocks();
+    });
+
+    test('Status update is handled: Position changes', () => {
+      expect(harness).toBeDefined();
+
+      // First update (previous state is unknown, so)
+      harness.checkUpdateState('{"position":100}', hap.Service.Window, new Map([
+        [hap.Characteristic.CurrentPosition, 100],
+        [hap.Characteristic.PositionState, hap.Characteristic.PositionState.STOPPED],
+        [hap.Characteristic.TargetPosition, 100],
+      ]));
+      harness.clearMocks();
+    });
+
+    test('HomeKit: Change target position', () => {
+      expect(harness).toBeDefined();
+
+      // Set current position to a known value, to check assumed position state
+      harness.checkUpdateState('{"position":50}', hap.Service.Window, new Map([
+        [hap.Characteristic.CurrentPosition, 50],
+        [hap.Characteristic.PositionState, hap.Characteristic.PositionState.STOPPED],
+        [hap.Characteristic.TargetPosition, 50],
+      ]));
+      harness.clearMocks();
+
+      // Check changing the position to a higher value
+      harness.checkHomeKitUpdate(hap.Service.Window, 'target_position', 51, { position: 51 });
+      const windowCovering = harness.getOrAddHandler(hap.Service.Window).checkCharacteristicUpdates(new Map([
+        [hap.Characteristic.PositionState, hap.Characteristic.PositionState.INCREASING],
+      ]));
+      harness.clearMocks();
+
+      // Receive status update with target position that was previously send.
+      // This should be ignored.
+      harness.checkUpdateStateIsIgnored('{"position":51}');
+      harness.clearMocks();
+
+      // Check changing the position to a lower value
+      harness.checkHomeKitUpdate(hap.Service.Window, 'target_position', 49, { position: 49 });
+      windowCovering.checkCharacteristicUpdates(new Map([
+        [hap.Characteristic.PositionState, hap.Characteristic.PositionState.DECREASING],
+      ]));
+      harness.clearMocks();
+
+      // Send two updates - should stop timer
+      harness.checkUpdateState('{"position":51}', hap.Service.Window, new Map([
+        [hap.Characteristic.CurrentPosition, 51],
+      ]));
+      harness.clearMocks();
+      harness.checkUpdateState('{"position":49}', hap.Service.Window, new Map([
+        [hap.Characteristic.CurrentPosition, 49],
+      ]));
+      harness.clearMocks();
+      harness.checkUpdateState('{"position":49}', hap.Service.Window, new Map([
+        [hap.Characteristic.CurrentPosition, 49],
+        [hap.Characteristic.PositionState, hap.Characteristic.PositionState.STOPPED],
+        [hap.Characteristic.TargetPosition, 49],
+      ]));
+      harness.clearMocks();
+
+      // Check timer - should request position
+      jest.runOnlyPendingTimers();
+      windowCovering.checkNoCharacteristicUpdates();
+      harness.checkNoGetKeysQueued();
+
+      // Check changing the position to the same value as was last received
+      harness.checkHomeKitUpdate(hap.Service.Window, 'target_position', 49, { position: 49 });
+      windowCovering.checkCharacteristicUpdates(new Map([
+        [hap.Characteristic.PositionState, hap.Characteristic.PositionState.STOPPED],
+      ]));
+      harness.clearMocks();
+
+      // Check timer - should request position
+      jest.runOnlyPendingTimers();
+      harness.checkGetKeysQueued('position');
+      harness.clearMocks();
+    });
+  });
 });


### PR DESCRIPTION
This PR aims to resolve my issue https://github.com/itavero/homebridge-z2m/issues/484

It adds the option to convert a cover accessory into a window one.

I based myself off the existing [switch converter](https://github.com/itavero/homebridge-z2m/blob/master/src/converters/switch.ts) 