### PR TITLE
Adaptive lighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Since version 1.0.0, we try to follow the [Semantic Versioning](https://semver.o
 
 ## [Unreleased]
 
+### Added
+
+- **Adaptive Lighting**: Added support for Adaptive Lighting. Currently this needs to be enabled *manually* in the plugin configuration, using [converter specific configuration for `light`](https://z2m.dev/light.html#converter-specific-configuration-light). In a future release this might get enabled by default. (see [#30](https://github.com/itavero/homebridge-z2m/issues/30) / [#488](https://github.com/itavero/homebridge-z2m/pull/488))
+
 ## [1.10.0] - 2022-12-09
 
 ### Added

--- a/config.schema.json
+++ b/config.schema.json
@@ -150,6 +150,17 @@
                 ]
               }
             }
+          },
+          "light": {
+            "title": "Light",
+            "type": "object",
+            "properties": {
+              "adaptive_lightning_enabled": {
+                "title": "Enable adaptive lightning",
+                "type": "boolean",
+                "required": false
+              }
+            }
           }
         }
       }

--- a/config.schema.json
+++ b/config.schema.json
@@ -155,8 +155,8 @@
             "title": "Light",
             "type": "object",
             "properties": {
-              "adaptive_lightning_enabled": {
-                "title": "Enable adaptive lightning",
+              "adaptive_lighting": {
+                "title": "Enable Adaptive Lighting",
                 "type": "boolean",
                 "required": false
               }

--- a/docs/light.md
+++ b/docs/light.md
@@ -9,3 +9,17 @@ The table below shows how the different features within this `exposes` entry are
 | `color_temp` | published, set | [Color Temperature](https://developers.homebridge.io/#/characteristic/ColorTemperature) | |
 | `color_hs` | published, set | [Hue](https://developers.homebridge.io/#/characteristic/Hue) and [Saturation](https://developers.homebridge.io/#/characteristic/Saturation) | Requires nested features `hue` and `saturation`. Preferred over `color_xy`. |
 | `color_xy` | published, set | [Hue](https://developers.homebridge.io/#/characteristic/Hue) and [Saturation](https://developers.homebridge.io/#/characteristic/Saturation) | Requires nested features `x` and `y`. Values translated by plugin. |
+
+## Converter specific configuration (`light`)
+
+- `adaptive_lighting`: Set to `true` to enable [Adaptive Lighting](https://support.apple.com/guide/iphone/control-accessories-iph0a717a8fd/ios#iph79e72e212). Apple requires a home hub for Adaptive Lighting to work. This feature is only available for lights that expose a *Color Temperature* characteristic.
+
+```json
+{
+  "converters": {
+    "light": {
+      "adaptive_lighting": true
+    }
+  }
+}
+```

--- a/src/converters/interfaces.ts
+++ b/src/converters/interfaces.ts
@@ -1,4 +1,4 @@
-import { Characteristic, Logger, Service } from 'homebridge';
+import { Characteristic, Controller, Logger, Service } from 'homebridge';
 import { ExposesEntry } from '../z2mModels';
 import { BasicLogger } from '../logger';
 
@@ -22,6 +22,8 @@ export interface BasicAccessory {
   isExperimentalFeatureEnabled(feature: string): boolean;
 
   getConverterConfiguration(tag: string): unknown | undefined;
+
+  configureController(controller: Controller): void;
 }
 
 export interface ServiceHandler {

--- a/src/converters/light.ts
+++ b/src/converters/light.ts
@@ -466,20 +466,21 @@ class LightHandler implements ServiceHandler {
 
   private handleAdaptiveLighting(value: number): boolean {
     // Adaptive Lighting active?
-    if (this.adaptiveLighting !== undefined && this.adaptiveLighting.isAdaptiveLightingActive()) {
+    if (this.colorTempExpose !== undefined && this.adaptiveLighting !== undefined && this.adaptiveLighting.isAdaptiveLightingActive()) {
       if (this.lastAdaptiveLightingTemperature === undefined) {
         this.lastAdaptiveLightingTemperature = value;
       } else {
         const change = Math.abs(this.lastAdaptiveLightingTemperature - value);
         if (change < 1) {
           this.accessory.log.debug(
-            `Adaptive Lighting: Color temperature ${value} skipped for ${this.accessory.displayName}. ` +
-              `Previous: ${this.lastAdaptiveLightingTemperature}`
+            `adaptive_lighting: ${this.accessory.displayName}: skipped ${this.colorTempExpose.property} (new: ${value}; ` +
+              `old: ${this.lastAdaptiveLightingTemperature}`
           );
           return false;
         }
 
-        this.accessory.log.debug(`Adaptive Lighting: Update for ${this.accessory.displayName} temperature=${value}`);
+        this.accessory.log.debug(`adaptive_lighting: ${this.accessory.displayName}: ${this.colorTempExpose.property} ${value}`);
+        this.lastAdaptiveLightingTemperature = value;
       }
     } else {
       this.resetAdaptiveLightingTemperature();

--- a/src/converters/light.ts
+++ b/src/converters/light.ts
@@ -1,4 +1,4 @@
-import { BasicAccessory, ServiceCreator, ServiceHandler } from './interfaces';
+import { BasicAccessory, ServiceCreator, ServiceHandler, ConverterConfigurationRegistry } from './interfaces';
 import {
   exposesCanBeGet,
   exposesCanBeSet,
@@ -18,7 +18,7 @@ import {
 } from '../z2mModels';
 import { hap } from '../hap';
 import { getOrAddCharacteristic } from '../helpers';
-import { Characteristic, CharacteristicSetCallback, CharacteristicValue, Service } from 'homebridge';
+import { Characteristic, CharacteristicSetCallback, CharacteristicValue, Controller, Service } from 'homebridge';
 import {
   CharacteristicMonitor,
   MappingCharacteristicMonitor,
@@ -29,7 +29,21 @@ import {
 import { convertHueSatToXy, convertMiredColorTemperatureToHueSat, convertXyToHueSat } from '../colorhelper';
 import { EXP_COLOR_MODE } from '../experimental';
 
+interface LightConfig {
+  adaptive_lightning_enabled?: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isLightConfig = (x: any): x is LightConfig =>
+  x !== undefined && (x.adaptive_lightning_enabled === undefined || typeof x.adaptive_lightning_enabled === 'boolean');
+
 export class LightCreator implements ServiceCreator {
+  public static readonly CONFIG_TAG = 'light';
+
+  constructor(converterConfigRegistry: ConverterConfigurationRegistry) {
+    converterConfigRegistry.registerConverterConfiguration(LightCreator.CONFIG_TAG, LightCreator.isValidConverterConfiguration);
+  }
+
   createServicesFromExposes(accessory: BasicAccessory, exposes: ExposesEntry[]): void {
     exposes
       .filter(
@@ -43,13 +57,28 @@ export class LightCreator implements ServiceCreator {
   }
 
   private createService(expose: ExposesEntryWithFeatures, accessory: BasicAccessory): void {
+    const converterConfig = accessory.getConverterConfiguration(LightCreator.CONFIG_TAG);
+    let adaptiveLightingEnabled = false;
+    if (isLightConfig(converterConfig) && converterConfig.adaptive_lightning_enabled) {
+      adaptiveLightingEnabled = true;
+    }
+
     try {
-      const handler = new LightHandler(expose, accessory);
+      const handler = new LightHandler(expose, accessory, adaptiveLightingEnabled);
       accessory.registerServiceHandler(handler);
     } catch (error) {
       accessory.log.warn(`Failed to setup light for accessory ${accessory.displayName} from expose "${JSON.stringify(expose)}": ${error}`);
     }
   }
+
+  private static isValidConverterConfiguration(config: unknown): boolean {
+    return isLightConfig(config);
+  }
+}
+
+interface AdaptiveLightingControl extends Controller {
+  isAdaptiveLightingActive(): boolean;
+  disableAdaptiveLighting(): void;
 }
 
 class LightHandler implements ServiceHandler {
@@ -69,13 +98,23 @@ class LightHandler implements ServiceHandler {
   private colorComponentAExpose: ExposesEntryWithProperty | undefined;
   private colorComponentBExpose: ExposesEntryWithProperty | undefined;
 
+  // Adaptive lighting
+  private adaptiveLighting: AdaptiveLightingControl | undefined;
+  private lastAdaptiveLightingTemperature: number | undefined;
+  private colorHueCharacteristic: Characteristic | undefined;
+  private colorSaturationCharacteristic: Characteristic | undefined;
+
   // Internal cache for hue and saturation. Needed in case X/Y is used
   private cached_hue = 0.0;
   private received_hue = false;
   private cached_saturation = 0.0;
   private received_saturation = false;
 
-  constructor(expose: ExposesEntryWithFeatures, private readonly accessory: BasicAccessory) {
+  constructor(
+    expose: ExposesEntryWithFeatures,
+    private readonly accessory: BasicAccessory,
+    private readonly adaptiveLightingEnabled: boolean
+  ) {
     const endpoint = expose.endpoint;
     this.identifier = LightHandler.generateIdentifier(endpoint);
 
@@ -107,6 +146,9 @@ class LightHandler implements ServiceHandler {
 
     // Color temperature
     this.tryCreateColorTemperature(features, service);
+
+    // Adaptive lighting
+    this.tryCreateAdaptiveLighting(service);
   }
 
   identifier: string;
@@ -193,8 +235,11 @@ class LightHandler implements ServiceHandler {
         return;
       }
 
-      getOrAddCharacteristic(service, hap.Characteristic.Hue).on('set', this.handleSetHue.bind(this));
-      getOrAddCharacteristic(service, hap.Characteristic.Saturation).on('set', this.handleSetSaturation.bind(this));
+      this.colorHueCharacteristic = getOrAddCharacteristic(service, hap.Characteristic.Hue).on('set', this.handleSetHue.bind(this));
+      this.colorSaturationCharacteristic = getOrAddCharacteristic(service, hap.Characteristic.Saturation).on(
+        'set',
+        this.handleSetSaturation.bind(this)
+      );
 
       if (this.colorExpose.name === 'color_hs') {
         this.monitors.push(
@@ -268,6 +313,25 @@ class LightHandler implements ServiceHandler {
     }
   }
 
+  private tryCreateAdaptiveLighting(service: Service) {
+    // Adaptive lightning is not enabled
+    if (!this.adaptiveLightingEnabled) {
+      return;
+    }
+
+    // Need at least brightness and color temperature to add Adaptive Lighting
+    if (this.brightnessExpose === undefined || this.colorTempExpose === undefined) {
+      return;
+    }
+
+    this.adaptiveLighting = new hap.AdaptiveLightingController(service).on('disable', this.resetAdaptiveLightingTemperature.bind(this));
+    this.accessory.configureController(this.adaptiveLighting);
+  }
+
+  private resetAdaptiveLightingTemperature(): void {
+    this.lastAdaptiveLightingTemperature = undefined;
+  }
+
   private handleSetOn(value: CharacteristicValue, callback: CharacteristicSetCallback): void {
     const data = {};
     data[this.stateExpose.property] = (value as boolean) ? this.stateExpose.value_on : this.stateExpose.value_off;
@@ -295,17 +359,22 @@ class LightHandler implements ServiceHandler {
   }
 
   private handleSetColorTemperature(value: CharacteristicValue, callback: CharacteristicSetCallback): void {
-    if (this.colorTempExpose !== undefined) {
+    if (this.colorTempExpose !== undefined && typeof value === 'number') {
       const data = {};
-      if (this.colorTempExpose.value_min !== undefined && value < this.colorTempExpose.value_min) {
+      if (value < this.colorTempExpose.value_min) {
         value = this.colorTempExpose.value_min;
       }
 
-      if (this.colorTempExpose.value_max !== undefined && value > this.colorTempExpose.value_max) {
+      if (value > this.colorTempExpose.value_max) {
         value = this.colorTempExpose.value_max;
       }
+
       data[this.colorTempExpose.property] = value;
-      this.accessory.queueDataForSetAction(data);
+
+      if (this.handleAdaptiveLighting(value)) {
+        this.accessory.queueDataForSetAction(data);
+      }
+
       callback(null);
     } else {
       callback(new Error('color temperature not supported'));
@@ -393,6 +462,38 @@ class LightHandler implements ServiceHandler {
       identifier += '_' + endpoint.trim();
     }
     return identifier;
+  }
+
+  private handleAdaptiveLighting(value: number): boolean {
+    // Adaptive Lighting active?
+    if (this.adaptiveLighting !== undefined && this.adaptiveLighting.isAdaptiveLightingActive()) {
+      if (this.lastAdaptiveLightingTemperature === undefined) {
+        this.lastAdaptiveLightingTemperature = value;
+      } else {
+        const change = Math.abs(this.lastAdaptiveLightingTemperature - value);
+        if (change < 1) {
+          this.accessory.log.debug(
+            `Adaptive Lighting: Color temperature ${value} skipped for ${this.accessory.displayName}. ` +
+              `Previous: ${this.lastAdaptiveLightingTemperature}`
+          );
+          return false;
+        }
+
+        this.accessory.log.info(`Adaptive Lightning: Update for ${this.accessory.displayName} temperature=${value}`);
+      }
+    } else {
+      this.resetAdaptiveLightingTemperature();
+    }
+
+    return true;
+  }
+
+  private updateHueAndSaturationBasedOnColorTemperature(value: number): void {
+    if (this.colorHueCharacteristic !== undefined && this.colorSaturationCharacteristic !== undefined) {
+      const color = hap.ColorUtils.colorTemperatureToHueAndSaturation(value, true);
+      this.colorHueCharacteristic.updateValue(color.hue);
+      this.colorSaturationCharacteristic.updateValue(color.saturation);
+    }
   }
 }
 

--- a/src/converters/light.ts
+++ b/src/converters/light.ts
@@ -30,12 +30,12 @@ import { convertHueSatToXy, convertMiredColorTemperatureToHueSat, convertXyToHue
 import { EXP_COLOR_MODE } from '../experimental';
 
 interface LightConfig {
-  adaptive_lightning_enabled?: boolean;
+  adaptive_lighting?: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isLightConfig = (x: any): x is LightConfig =>
-  x !== undefined && (x.adaptive_lightning_enabled === undefined || typeof x.adaptive_lightning_enabled === 'boolean');
+  x !== undefined && (x.adaptive_lighting === undefined || typeof x.adaptive_lighting === 'boolean');
 
 export class LightCreator implements ServiceCreator {
   public static readonly CONFIG_TAG = 'light';
@@ -59,7 +59,7 @@ export class LightCreator implements ServiceCreator {
   private createService(expose: ExposesEntryWithFeatures, accessory: BasicAccessory): void {
     const converterConfig = accessory.getConverterConfiguration(LightCreator.CONFIG_TAG);
     let adaptiveLightingEnabled = false;
-    if (isLightConfig(converterConfig) && converterConfig.adaptive_lightning_enabled) {
+    if (isLightConfig(converterConfig) && converterConfig.adaptive_lighting) {
       adaptiveLightingEnabled = true;
     }
 
@@ -314,7 +314,7 @@ class LightHandler implements ServiceHandler {
   }
 
   private tryCreateAdaptiveLighting(service: Service) {
-    // Adaptive lightning is not enabled
+    // Adaptive lighting is not enabled
     if (!this.adaptiveLightingEnabled) {
       return;
     }
@@ -479,7 +479,7 @@ class LightHandler implements ServiceHandler {
           return false;
         }
 
-        this.accessory.log.info(`Adaptive Lightning: Update for ${this.accessory.displayName} temperature=${value}`);
+        this.accessory.log.debug(`Adaptive Lighting: Update for ${this.accessory.displayName} temperature=${value}`);
       }
     } else {
       this.resetAdaptiveLightingTemperature();

--- a/src/docgen/docs_accessory.ts
+++ b/src/docgen/docs_accessory.ts
@@ -1,4 +1,4 @@
-import { Service } from 'homebridge';
+import { Controller, Service } from 'homebridge';
 import { BasicAccessory, ServiceHandler } from '../converters/interfaces';
 import { BasicLogger } from '../logger';
 
@@ -20,10 +20,17 @@ export class DocsAccessory implements BasicAccessory {
 
   private readonly services: Service[] = [];
   private readonly handlerIds = new Set<string>();
+  private readonly controllers = new Set<string>();
 
   constructor(readonly displayName: string) {}
 
-  getConverterConfiguration(): unknown {
+  getConverterConfiguration(tag: string): unknown | undefined {
+    if (tag === 'light') {
+      // Return a config that has adaptive lighting enabled
+      return {
+        adaptive_lighting: true,
+      };
+    }
     return {};
   }
 
@@ -80,5 +87,13 @@ export class DocsAccessory implements BasicAccessory {
 
   isServiceHandlerIdKnown(identifier: string): boolean {
     return this.handlerIds.has(identifier);
+  }
+
+  configureController(controller: Controller): void {
+    this.controllers.add(controller.constructor.name);
+  }
+
+  getControllerNames(): string[] {
+    return [...this.controllers].sort();
   }
 }

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -1,4 +1,4 @@
-import { HAPStatus, PlatformAccessory, Service } from 'homebridge';
+import { Controller, HAPStatus, PlatformAccessory, Service } from 'homebridge';
 import { Zigbee2mqttPlatform } from './platform';
 import { ExtendedTimer } from './timer';
 import { hap } from './hap';
@@ -481,5 +481,9 @@ export class Zigbee2mqttAccessory implements BasicAccessory {
       name += ` ${subType}`;
     }
     return name;
+  }
+
+  configureController(controller: Controller) {
+    this.accessory.configureController(controller);
   }
 }

--- a/test/exposes/innr/rb_249_t.json
+++ b/test/exposes/innr/rb_249_t.json
@@ -1,0 +1,143 @@
+[
+  {
+    "type": "light",
+    "features": [
+      {
+        "type": "binary",
+        "name": "state",
+        "property": "state",
+        "access": 7,
+        "value_on": "ON",
+        "value_off": "OFF",
+        "value_toggle": "TOGGLE",
+        "description": "On/off state of this light"
+      },
+      {
+        "type": "numeric",
+        "name": "brightness",
+        "property": "brightness",
+        "access": 7,
+        "value_min": 0,
+        "value_max": 254,
+        "description": "Brightness of this light"
+      },
+      {
+        "type": "numeric",
+        "name": "color_temp",
+        "property": "color_temp",
+        "access": 7,
+        "unit": "mired",
+        "value_min": 200,
+        "value_max": 454,
+        "description": "Color temperature of this light",
+        "presets": [
+          {
+            "name": "coolest",
+            "value": 200,
+            "description": "Coolest temperature supported"
+          },
+          {
+            "name": "cool",
+            "value": 250,
+            "description": "Cool temperature (250 mireds / 4000 Kelvin)"
+          },
+          {
+            "name": "neutral",
+            "value": 370,
+            "description": "Neutral temperature (370 mireds / 2700 Kelvin)"
+          },
+          {
+            "name": "warm",
+            "value": 454,
+            "description": "Warm temperature (454 mireds / 2200 Kelvin)"
+          },
+          {
+            "name": "warmest",
+            "value": 454,
+            "description": "Warmest temperature supported"
+          }
+        ]
+      },
+      {
+        "type": "numeric",
+        "name": "color_temp_startup",
+        "property": "color_temp_startup",
+        "access": 7,
+        "unit": "mired",
+        "value_min": 200,
+        "value_max": 454,
+        "description": "Color temperature after cold power on of this light",
+        "presets": [
+          {
+            "name": "coolest",
+            "value": 200,
+            "description": "Coolest temperature supported"
+          },
+          {
+            "name": "cool",
+            "value": 250,
+            "description": "Cool temperature (250 mireds / 4000 Kelvin)"
+          },
+          {
+            "name": "neutral",
+            "value": 370,
+            "description": "Neutral temperature (370 mireds / 2700 Kelvin)"
+          },
+          {
+            "name": "warm",
+            "value": 454,
+            "description": "Warm temperature (454 mireds / 2200 Kelvin)"
+          },
+          {
+            "name": "warmest",
+            "value": 454,
+            "description": "Warmest temperature supported"
+          },
+          {
+            "name": "previous",
+            "value": 65535,
+            "description": "Restore previous color_temp on cold power on"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "effect",
+    "property": "effect",
+    "access": 2,
+    "values": [
+      "blink",
+      "breathe",
+      "okay",
+      "channel_change",
+      "finish_effect",
+      "stop_effect"
+    ],
+    "description": "Triggers an effect on the light (e.g. make light blink for a few seconds)"
+  },
+  {
+    "type": "enum",
+    "name": "power_on_behavior",
+    "property": "power_on_behavior",
+    "access": 7,
+    "values": [
+      "off",
+      "on",
+      "toggle",
+      "previous"
+    ],
+    "description": "Controls the behavior when the device is powered on after power loss"
+  },
+  {
+    "type": "numeric",
+    "name": "linkquality",
+    "property": "linkquality",
+    "access": 1,
+    "unit": "lqi",
+    "description": "Link quality (signal strength)",
+    "value_min": 0,
+    "value_max": 255
+  }
+]

--- a/test/exposes/namron/4512700.json
+++ b/test/exposes/namron/4512700.json
@@ -1,0 +1,64 @@
+[
+  {
+    "type": "light",
+    "features": [
+      {
+        "type": "binary",
+        "name": "state",
+        "property": "state",
+        "access": 7,
+        "value_on": "ON",
+        "value_off": "OFF",
+        "value_toggle": "TOGGLE",
+        "description": "On/off state of this light"
+      },
+      {
+        "type": "numeric",
+        "name": "brightness",
+        "property": "brightness",
+        "access": 7,
+        "value_min": 0,
+        "value_max": 254,
+        "description": "Brightness of this light"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "effect",
+    "property": "effect",
+    "access": 2,
+    "values": [
+      "blink",
+      "breathe",
+      "okay",
+      "channel_change",
+      "finish_effect",
+      "stop_effect"
+    ],
+    "description": "Triggers an effect on the light (e.g. make light blink for a few seconds)"
+  },
+  {
+    "type": "enum",
+    "name": "power_on_behavior",
+    "property": "power_on_behavior",
+    "access": 7,
+    "values": [
+      "off",
+      "on",
+      "toggle",
+      "previous"
+    ],
+    "description": "Controls the behavior when the device is powered on after power loss"
+  },
+  {
+    "type": "numeric",
+    "name": "linkquality",
+    "property": "linkquality",
+    "access": 1,
+    "unit": "lqi",
+    "description": "Link quality (signal strength)",
+    "value_min": 0,
+    "value_max": 255
+  }
+]

--- a/test/light.spec.ts
+++ b/test/light.spec.ts
@@ -787,4 +787,98 @@ describe('Light', () => {
       harness.checkSetDataQueued({ color: { hue: 300, saturation: 100 } });
     });
   });
+
+  describe('Innr RB-249-T (Adaptive Lighting turned on)', () => {
+    // Shared "state"
+    let deviceExposes: ExposesEntry[] = [];
+    let harness: ServiceHandlersTestHarness;
+
+    beforeEach(() => {
+      // Only test service creation for first test case and reuse harness afterwards
+      if (deviceExposes.length === 0 && harness === undefined) {
+        // Load exposes from JSON
+        deviceExposes = loadExposesFromFile('innr/rb_249_t.json');
+        expect(deviceExposes.length).toBeGreaterThan(0);
+
+        // Check service creation
+        const newHarness = new ServiceHandlersTestHarness();
+        newHarness.addConverterConfiguration('light', { adaptive_lighting: true });
+        newHarness.numberOfExpectedControllers = 1;
+        const lightbulb = newHarness
+          .getOrAddHandler(hap.Service.Lightbulb)
+          .addExpectedCharacteristic('state', hap.Characteristic.On, true)
+          .addExpectedCharacteristic('brightness', hap.Characteristic.Brightness, true)
+          .addExpectedCharacteristic('color_temp', hap.Characteristic.ColorTemperature, true);
+        newHarness.prepareCreationMocks();
+
+        newHarness.callCreators(deviceExposes);
+
+        newHarness.checkCreationExpectations();
+        newHarness.checkHasMainCharacteristics();
+
+        newHarness.checkExpectedGetableKeys(['state', 'brightness', 'color_temp']);
+
+        // Expect range of color temperature to be configured
+        lightbulb.checkCharacteristicPropertiesHaveBeenSet('color_temp', {
+          minValue: 200,
+          maxValue: 454,
+          minStep: 1,
+        });
+        harness = newHarness;
+      }
+
+      harness?.clearMocks();
+      const brightnessCharacteristicMock = harness?.getOrAddHandler(hap.Service.Lightbulb).getCharacteristicMock('brightness');
+      if (brightnessCharacteristicMock !== undefined) {
+        brightnessCharacteristicMock.props.minValue = 0;
+        brightnessCharacteristicMock.props.maxValue = 100;
+      }
+    });
+
+    afterEach(() => {
+      verifyAllWhenMocksCalled();
+      resetAllWhenMocks();
+    });
+
+    test('Status update is handled: State On', () => {
+      expect(harness).toBeDefined();
+      harness.checkSingleUpdateState('{"state":"ON"}', hap.Service.Lightbulb, hap.Characteristic.On, true);
+    });
+
+    test('Status update is handled: State Off', () => {
+      expect(harness).toBeDefined();
+      harness.checkSingleUpdateState('{"state":"OFF"}', hap.Service.Lightbulb, hap.Characteristic.On, false);
+    });
+
+    test('Status update is handled: Brightness 50%', () => {
+      expect(harness).toBeDefined();
+      harness.getOrAddHandler(hap.Service.Lightbulb).prepareGetCharacteristicMock('brightness');
+      harness.checkSingleUpdateState('{"brightness":127}', hap.Service.Lightbulb, hap.Characteristic.Brightness, 50);
+    });
+
+    test('HomeKit: Turn On', () => {
+      expect(harness).toBeDefined();
+      harness.checkHomeKitUpdateWithSingleValue(hap.Service.Lightbulb, 'state', true, 'ON');
+    });
+
+    test('HomeKit: Turn Off', () => {
+      expect(harness).toBeDefined();
+      harness.checkHomeKitUpdateWithSingleValue(hap.Service.Lightbulb, 'state', false, 'OFF');
+    });
+
+    test('HomeKit: Brightness to 50%', () => {
+      expect(harness).toBeDefined();
+      harness.checkHomeKitUpdateWithSingleValue(hap.Service.Lightbulb, 'brightness', 50, 127);
+    });
+
+    test('HomeKit: Brightness to 0%', () => {
+      expect(harness).toBeDefined();
+      harness.checkHomeKitUpdateWithSingleValue(hap.Service.Lightbulb, 'brightness', 0, 0);
+    });
+
+    test('HomeKit: Brightness to 100%', () => {
+      expect(harness).toBeDefined();
+      harness.checkHomeKitUpdateWithSingleValue(hap.Service.Lightbulb, 'brightness', 100, 254);
+    });
+  });
 });


### PR DESCRIPTION
Continuation of #60 to add support for Adaptive Lighting (#30).

* Rebased #60 on top of master
* Made Adaptive Lighting opt-in

One oddity that I've found is that HomeKit does not seem to respect disabling adaptive lighting for a light once it has been enabled the first time, it's still unclear if there is anything I can do to support this.

### To Do

- [ ] Add automated tests
- [x] Update CHANGELOG
- [x] Update documentation
- [x] Update documentation generator

