### PR TITLE
Add special handling for very low brightness values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Since version 1.0.0, we try to follow the [Semantic Versioning](https://semver.o
 
 ## [Unreleased]
 
+### Fixed
+
+- Non-zero brightness levels below 1% are now rounded up to 1%. (see [#673](https://github.com/itavero/homebridge-z2m/issues/673))
+
 ## [1.11.0-beta.3] - 2024-01-04
 
 ### Changed

--- a/src/converters/light.ts
+++ b/src/converters/light.ts
@@ -347,8 +347,8 @@ class LightHandler implements ServiceHandler {
           hap.Characteristic.Brightness,
           this.brightnessExpose.value_min,
           this.brightnessExpose.value_max,
-          null,
-          null,
+          undefined,
+          undefined,
           true
         )
       );

--- a/src/converters/light.ts
+++ b/src/converters/light.ts
@@ -347,6 +347,8 @@ class LightHandler implements ServiceHandler {
           hap.Characteristic.Brightness,
           this.brightnessExpose.value_min,
           this.brightnessExpose.value_max,
+          null,
+          null,
           true
         )
       );

--- a/src/converters/light.ts
+++ b/src/converters/light.ts
@@ -346,7 +346,8 @@ class LightHandler implements ServiceHandler {
           service,
           hap.Characteristic.Brightness,
           this.brightnessExpose.value_min,
-          this.brightnessExpose.value_max
+          this.brightnessExpose.value_max,
+          true
         )
       );
     }

--- a/src/converters/monitor.ts
+++ b/src/converters/monitor.ts
@@ -98,7 +98,7 @@ export class NumericCharacteristicMonitor extends BaseCharacteristicMonitor {
     private readonly input_max: number,
     private readonly output_min?: number | undefined,
     private readonly output_max?: number | undefined,
-    private readonly roundValue: boolean = false
+    private readonly ceilAlmostZeroValue: boolean = false
   ) {
     super(key, service, characteristic);
     if (input_min === input_max) {
@@ -142,7 +142,7 @@ export class NumericCharacteristicMonitor extends BaseCharacteristicMonitor {
     const percentage = (input - this.input_min) / (this.input_max - this.input_min);
 
     const result = out_minimum + percentage * (out_maximum - out_minimum);
-    if (this.roundValue && result > 0 && result < 1) {
+    if (this.ceilAlmostZeroValue && result > 0 && result < 1) {
       return 1;
     }
     return result;

--- a/src/converters/monitor.ts
+++ b/src/converters/monitor.ts
@@ -140,6 +140,15 @@ export class NumericCharacteristicMonitor extends BaseCharacteristicMonitor {
     }
     const percentage = (input - this.input_min) / (this.input_max - this.input_min);
 
-    return out_minimum + percentage * (out_maximum - out_minimum);
+    const result = out_minimum + percentage * (out_maximum - out_minimum);
+    if (
+      result < 1 &&
+      result > 0 &&
+      actualCharacteristic !== undefined &&
+      actualCharacteristic.UUID === '00000008-0000-1000-8000-0026BB765291'
+    ) {
+      return 1;
+    }
+    return result;
   }
 }

--- a/src/converters/monitor.ts
+++ b/src/converters/monitor.ts
@@ -97,7 +97,8 @@ export class NumericCharacteristicMonitor extends BaseCharacteristicMonitor {
     private readonly input_min: number,
     private readonly input_max: number,
     private readonly output_min?: number | undefined,
-    private readonly output_max?: number | undefined
+    private readonly output_max?: number | undefined,
+    roundValue: boolean = false,
   ) {
     super(key, service, characteristic);
     if (input_min === input_max) {
@@ -141,12 +142,7 @@ export class NumericCharacteristicMonitor extends BaseCharacteristicMonitor {
     const percentage = (input - this.input_min) / (this.input_max - this.input_min);
 
     const result = out_minimum + percentage * (out_maximum - out_minimum);
-    if (
-      result < 1 &&
-      result > 0 &&
-      actualCharacteristic !== undefined &&
-      actualCharacteristic.UUID === '00000008-0000-1000-8000-0026BB765291'
-    ) {
+    if (this.roundValue && result > 0 && result < 1) {
       return 1;
     }
     return result;

--- a/src/converters/monitor.ts
+++ b/src/converters/monitor.ts
@@ -98,7 +98,7 @@ export class NumericCharacteristicMonitor extends BaseCharacteristicMonitor {
     private readonly input_max: number,
     private readonly output_min?: number | undefined,
     private readonly output_max?: number | undefined,
-    roundValue: boolean = false,
+    private readonly roundValue: boolean = false
   ) {
     super(key, service, characteristic);
     if (input_min === input_max) {

--- a/test/light.spec.ts
+++ b/test/light.spec.ts
@@ -197,7 +197,6 @@ describe('Light', () => {
       if (brightnessCharacteristicMock !== undefined) {
         brightnessCharacteristicMock.props.minValue = 0;
         brightnessCharacteristicMock.props.maxValue = 100;
-        brightnessCharacteristicMock.UUID = '00000008-0000-1000-8000-0026BB765291';
       }
     });
 

--- a/test/light.spec.ts
+++ b/test/light.spec.ts
@@ -197,6 +197,7 @@ describe('Light', () => {
       if (brightnessCharacteristicMock !== undefined) {
         brightnessCharacteristicMock.props.minValue = 0;
         brightnessCharacteristicMock.props.maxValue = 100;
+        brightnessCharacteristicMock.UUID = '00000008-0000-1000-8000-0026BB765291';
       }
     });
 
@@ -225,6 +226,18 @@ describe('Light', () => {
         expect(harness).toBeDefined();
         harness.getOrAddHandler(hap.Service.Lightbulb).prepareGetCharacteristicMock('brightness');
         harness.checkSingleUpdateState('{"brightness":0}', hap.Service.Lightbulb, hap.Characteristic.Brightness, 0);
+      });
+
+      test('Brightness 1% (1/254 from Zigbee)', () => {
+        expect(harness).toBeDefined();
+        harness.getOrAddHandler(hap.Service.Lightbulb).prepareGetCharacteristicMock('brightness');
+        harness.checkSingleUpdateState('{"brightness":1}', hap.Service.Lightbulb, hap.Characteristic.Brightness, 1);
+      });
+
+      test('Brightness 1% (2/254 from Zigbee)', () => {
+        expect(harness).toBeDefined();
+        harness.getOrAddHandler(hap.Service.Lightbulb).prepareGetCharacteristicMock('brightness');
+        harness.checkSingleUpdateState('{"brightness":2}', hap.Service.Lightbulb, hap.Characteristic.Brightness, 1);
       });
 
       test('Brightness 50%', () => {


### PR DESCRIPTION
An improved (and tested) version of https://github.com/itavero/homebridge-z2m/pull/674, that simply prevents HomeKit from rounding down very low **brightness** values, while leaving all other numeric characteristics unaffected.

Fixes https://github.com/itavero/homebridge-z2m/issues/673