### PR TITLE
Process devices not yet supported by Zigbee2MQTT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Since version 1.0.0, we try to follow the [Semantic Versioning](https://semver.o
 
 ## [Unreleased]
 
+### Changed
+
+- Process devices not yet supported by Zigbee2MQTT if they provide exposes information. This should allow automatically detected features to already be exposed.
+
 ### Fixed
 
 - Non-zero brightness levels below 1% are now rounded up to 1%. (see [#673](https://github.com/itavero/homebridge-z2m/issues/673))

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -583,7 +583,7 @@ export class Zigbee2mqttPlatform implements DynamicPlatformPlugin {
   }
 
   private createOrUpdateAccessory(device: DeviceListEntry) {
-    if (!device.supported || !isDeviceDefinition(device.definition) || this.isDeviceExcluded(device)) {
+    if (!isDeviceDefinition(device.definition) || this.isDeviceExcluded(device)) {
       return;
     }
     const uuid_input = isDeviceListEntryForGroup(device) ? `group-${device.group_id}` : device.ieee_address;


### PR DESCRIPTION
Process devices not yet supported by Zigbee2MQTT if exposes informaton is available.

Noticed this week that a device not supported by Zigbee2MQTT yet, works just fine due to the changes made in Zigbee2MQTT earlier.
However, homebridge-z2m still had a check on `supported` which prevented the device from showing up in HomeKit.

Removing this check doesn't seem to give any problems because of the improvements made to the other model checks earlier.