### PR TITLE
Adaptive Lighting tweaks

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -161,9 +161,29 @@
             "type": "object",
             "properties": {
               "adaptive_lighting": {
-                "title": "Enable Adaptive Lighting",
-                "type": "boolean",
-                "required": false
+                "title": "Adaptive Lighting",
+                "type": "object",
+                "required": false,
+                "properties": {
+                  "enabled": {
+                    "title": "Enable adaptive lighting",
+                    "type": "boolean",
+                    "default": true,
+                    "required": false
+                  },
+                  "only_when_on": {
+                    "title": "Only send color temperature updates when light is on",
+                    "type": "boolean",
+                    "default": true,
+                    "required": false
+                  },
+                  "transition": {
+                    "title": "Transition time",
+                    "type": "integer",
+                    "default": 0,
+                    "required": false
+                  }
+                }
               }
             }
           }

--- a/docs/light.md
+++ b/docs/light.md
@@ -12,8 +12,9 @@ The table below shows how the different features within this `exposes` entry are
 
 ## Converter specific configuration (`light`)
 
-- `adaptive_lighting`: Set to `true` to enable [Adaptive Lighting](https://support.apple.com/guide/iphone/control-accessories-iph0a717a8fd/ios#iph79e72e212). Apple requires a home hub for Adaptive Lighting to work. This feature is only available for lights that expose a *Color Temperature* characteristic.
+- `adaptive_lighting`: Set to `false` to disable [Adaptive Lighting](https://support.apple.com/guide/iphone/control-accessories-iph0a717a8fd/ios#iph79e72e212). Apple requires a home hub for Adaptive Lighting to work. This feature is only available for lights that expose a *Color Temperature* characteristic.
   Additionally you can also configure the following options for Adaptive Lighting:
+  - `enabled`: Set to `true` to enable Adaptive Lighting. Defaults to `true`. (same as setting `adaptive_lighting` to a boolean value)
   - `only_when_on`: Only update the color temperature when the light is on. Defaults to `true`.
   - `transition`: Transition time to send along with the color temperature change when the light is on. If not defined, `transition` will not be send.
 
@@ -22,6 +23,7 @@ The table below shows how the different features within this `exposes` entry are
   "converters": {
     "light": {
       "adaptive_lighting": {
+        "enabled": true,
         "only_when_on": true,
         "transition": 0.5
       }

--- a/test/light.spec.ts
+++ b/test/light.spec.ts
@@ -166,6 +166,8 @@ describe('Light', () => {
 
         // Check service creation
         const newHarness = new ServiceHandlersTestHarness();
+        newHarness.addConverterConfiguration('light', { adaptive_lighting: { enabled: false } });
+        newHarness.numberOfExpectedControllers = 0;
         const lightbulb = newHarness
           .getOrAddHandler(hap.Service.Lightbulb)
           .addExpectedCharacteristic('state', hap.Characteristic.On, true)
@@ -491,6 +493,8 @@ describe('Light', () => {
 
         // Check service creation
         const newHarness = new ServiceHandlersTestHarness();
+        newHarness.addConverterConfiguration('light', { adaptive_lighting: false });
+        newHarness.numberOfExpectedControllers = 0;
         newHarness.addExperimentalFeatureFlags(EXP_COLOR_MODE);
         const lightbulb = newHarness
           .getOrAddHandler(hap.Service.Lightbulb)
@@ -672,6 +676,7 @@ describe('Light', () => {
 
         // Check service creation
         const newHarness = new ServiceHandlersTestHarness();
+        newHarness.numberOfExpectedControllers = 1;
         const lightbulb = newHarness
           .getOrAddHandler(hap.Service.Lightbulb)
           .addExpectedCharacteristic('state', hap.Characteristic.On, true)
@@ -799,6 +804,7 @@ describe('Light', () => {
       harness.checkSetDataQueued({ color: { hue: 300, saturation: 100 } });
     });
   });
+
   describe('Namron Zigbee Dimmer (Adaptive Lighting ignored)', () => {
     // Shared "state"
     let deviceExposes: ExposesEntry[] = [];
@@ -857,7 +863,7 @@ describe('Light', () => {
     });
   });
 
-  describe('Innr RB-249-T (Adaptive Lighting turned on)', () => {
+  describe('Innr RB-249-T', () => {
     // Shared "state"
     let deviceExposes: ExposesEntry[] = [];
     let harness: ServiceHandlersTestHarness;
@@ -871,7 +877,6 @@ describe('Light', () => {
 
         // Check service creation
         const newHarness = new ServiceHandlersTestHarness();
-        newHarness.addConverterConfiguration('light', { adaptive_lighting: true });
         newHarness.numberOfExpectedControllers = 1;
         const lightbulb = newHarness
           .getOrAddHandler(hap.Service.Lightbulb)

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -207,7 +207,7 @@ class ServiceHandlerTestData implements ServiceHandlerContainer {
 
   checkCharacteristicPropertiesHaveBeenSet(identifier: string, props: Partial<CharacteristicProps>): ServiceHandlerContainer {
     const mock = this.getCharacteristicMock(identifier);
-    expect(mock.setProps).toBeCalledTimes(1).toBeCalledWith(props);
+    expect(mock.setProps).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(props);
 
     return this;
   }
@@ -241,10 +241,10 @@ class ServiceHandlerTestData implements ServiceHandlerContainer {
   checkCharacteristicUpdates(
     expectedUpdates: Map<WithUUID<{ new (): Characteristic }> | string, CharacteristicValue>
   ): ServiceHandlerContainer {
-    expect(this.serviceMock.updateCharacteristic).toBeCalledTimes(expectedUpdates.size);
+    expect(this.serviceMock.updateCharacteristic).toHaveBeenCalledTimes(expectedUpdates.size);
 
     for (const [characteristic, value] of expectedUpdates) {
-      expect(this.serviceMock.updateCharacteristic).toBeCalledWith(characteristic, value);
+      expect(this.serviceMock.updateCharacteristic).toHaveBeenCalledWith(characteristic, value);
     }
     return this;
   }
@@ -256,13 +256,13 @@ class ServiceHandlerTestData implements ServiceHandlerContainer {
   checkCharacteristicUpdateValues(expectedUpdates: Map<string, CharacteristicValue>): ServiceHandlerContainer {
     for (const [identifier, value] of expectedUpdates) {
       const mock = this.getCharacteristicMock(identifier);
-      expect(mock.updateValue).toBeCalledTimes(1).toBeCalledWith(value);
+      expect(mock.updateValue).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(value);
     }
     return this;
   }
 
   checkNoCharacteristicUpdates(): ServiceHandlerContainer {
-    expect(this.serviceMock.updateCharacteristic).not.toBeCalled();
+    expect(this.serviceMock.updateCharacteristic).not.toHaveBeenCalled();
     return this;
   }
 
@@ -276,7 +276,7 @@ class ServiceHandlerTestData implements ServiceHandlerContainer {
     const callbackMock = jest.fn();
     mapping.setFunction(setValue, callbackMock);
 
-    expect(callbackMock).toBeCalledTimes(1).toBeCalledWith(null);
+    expect(callbackMock).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(null);
 
     return this;
   }
@@ -450,7 +450,7 @@ export class ServiceHandlersTestHarness {
     let expectedCallsToGetOrAddService = 0;
     let expectedCallsToRegisterServiceHandler = 0;
 
-    expect(this.accessoryMock.configureController).toBeCalledTimes(this.numberOfExpectedControllers);
+    expect(this.accessoryMock.configureController).toHaveBeenCalledTimes(this.numberOfExpectedControllers);
 
     for (const handler of this.handlers.values()) {
       expect(this.accessoryMock.isServiceHandlerIdKnown).toHaveBeenCalledWith(handler.serviceIdentifier);
@@ -464,9 +464,9 @@ export class ServiceHandlersTestHarness {
         }
       }
 
-      expect(handler.serviceMock.getCharacteristic).toBeCalledTimes(characteristicCount);
+      expect(handler.serviceMock.getCharacteristic).toHaveBeenCalledTimes(characteristicCount);
 
-      expect(handler.serviceMock.addCharacteristic).toBeCalledTimes(characteristicCount);
+      expect(handler.serviceMock.addCharacteristic).toHaveBeenCalledTimes(characteristicCount);
 
       ++expectedCallsToRegisterServiceHandler;
       expect(this.accessoryMock.registerServiceHandler.mock.calls.length).toBeGreaterThanOrEqual(expectedCallsToRegisterServiceHandler);
@@ -481,9 +481,9 @@ export class ServiceHandlersTestHarness {
   private checkCharacteristicExpectations(handler: ServiceHandlerTestData) {
     for (const mapping of handler.characteristics.values()) {
       if (mapping.characteristic !== undefined) {
-        expect(handler.serviceMock.getCharacteristic).toBeCalledWith(mapping.characteristic);
+        expect(handler.serviceMock.getCharacteristic).toHaveBeenCalledWith(mapping.characteristic);
 
-        expect(handler.serviceMock.addCharacteristic).toBeCalledWith(mapping.characteristic);
+        expect(handler.serviceMock.addCharacteristic).toHaveBeenCalledWith(mapping.characteristic);
 
         if (mapping.doExpectSet && mapping.mock !== undefined) {
           expect(mapping.mock.on).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(CharacteristicEventTypes.SET, expect.anything());
@@ -572,19 +572,19 @@ export class ServiceHandlersTestHarness {
   }
 
   checkSetDataQueued(expectedData: unknown) {
-    expect(this.accessoryMock.queueDataForSetAction).toBeCalledTimes(1).toBeCalledWith(expectedData);
+    expect(this.accessoryMock.queueDataForSetAction).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedData);
   }
 
   checkNoSetDataQueued() {
-    expect(this.accessoryMock.queueDataForSetAction).not.toBeCalled();
+    expect(this.accessoryMock.queueDataForSetAction).not.toHaveBeenCalled();
   }
 
   checkGetKeysQueued(expectedKeys: string | string[]) {
-    expect(this.accessoryMock.queueKeyForGetAction).toBeCalledTimes(1).toBeCalledWith(expectedKeys);
+    expect(this.accessoryMock.queueKeyForGetAction).toHaveBeenCalledTimes(1).toHaveBeenCalledWith(expectedKeys);
   }
 
   checkNoGetKeysQueued() {
-    expect(this.accessoryMock.queueKeyForGetAction).not.toBeCalled();
+    expect(this.accessoryMock.queueKeyForGetAction).not.toHaveBeenCalled();
   }
 
   clearMocks(): void {


### PR DESCRIPTION
Tweaks in preparation of new release:
* Enable by default.
* Reset color temperature reference when changing brightness or state to on via HomeKit

Still to do:
- [ ] Fix tests
- [ ] Update changelog
- [ ] Run test in "production"