### PR TITLE
Do not request brightness of light by default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,9 @@
   },
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "cSpell.words": [
+    "Elgato",
+    "Zigbee"
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Since version 1.0.0, we try to follow the [Semantic Versioning](https://semver.o
 ### Changed
 
 - Light sensor will now use `illuminance` property if `illuminance_lux` is not available. This should fix compatibility with the new major v2 release of Zigbee2MQTT. (see [#966](https://github.com/itavero/homebridge-z2m/issues/966))
+- Brightness for a Light is no longer requested by default. This should prevent issues when the light is off.
+  Old behavior can be restored using the `request_brightness` option in the converter specific configuration.
+  (see [#882](https://github.com/itavero/homebridge-z2m/issues/882))
 
 ## [1.11.0-beta.6] - 2024-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Since version 1.0.0, we try to follow the [Semantic Versioning](https://semver.o
 
 - Light sensor will now use `illuminance` property if `illuminance_lux` is not available. This should fix compatibility with the new major v2 release of Zigbee2MQTT. (see [#966](https://github.com/itavero/homebridge-z2m/issues/966))
 - Brightness for a Light is no longer requested by default. This should prevent issues when the light is off.
-  Old behavior can be restored using the `request_brightness` option in the converter specific configuration.
+  Old behavior can be restored using the `request_brightness` option in the converter-specific configuration.
   (see [#882](https://github.com/itavero/homebridge-z2m/issues/882))
 
 ## [1.11.0-beta.6] - 2024-06-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@ Based on v1.9.2, as v1.9.3 was made later as a hotfix.
 
 ### Fixed
 
-- Added additional checks to prevent certain errors from occuring during creation of a service handler. (see [#443](https://github.com/itavero/homebridge-z2m/issues/443))
+- Added additional checks to prevent certain errors from occurring during creation of a service handler. (see [#443](https://github.com/itavero/homebridge-z2m/issues/443))
 - Removed some default values from `config.schema.json` to prevent certain illegal configurations from being created by accident.
 
 ## [1.9.0] - 2022-06-29
@@ -461,7 +461,7 @@ For `cover` devices the following changes/fixes are in this release:
 
 ### Changed
 
-- Restore BatteryServuce and WindowConvering properly on start up.
+- Restore BatteryService and WindowCovering properly on start up.
 - Improve state determination for WindowCovering.
 
 [unreleased]: https://github.com/itavero/homebridge-z2m/compare/v1.11.0-beta.6...HEAD

--- a/docs/light.md
+++ b/docs/light.md
@@ -1,4 +1,5 @@
 # Light
+
 If the device definition from Zigbee2MQTT contains one or more `exposes` entries of type `light` that at least have a feature named `state` (i.e. on/off), a [Lightbulb](https://developers.homebridge.io/#/service/Lightbulb) service will be created.
 The table below shows how the different features within this `exposes` entry are mapped to characteristics.
 
@@ -16,6 +17,7 @@ The table below shows how the different features within this `exposes` entry are
   Additionally you can also configure the following options for Adaptive Lighting:
   - `only_when_on`: Only update the color temperature when the light is on. Defaults to `true`.
   - `transition`: Transition time to send along with the color temperature change when the light is on. If not defined, `transition` will not be send.
+- `request_brightness`: Set to `true` to allow the brightness to be requested (if possible). Defaults to `false`, as this can cause issues when the light is off.
 
 ```json
 {

--- a/docs/light.md
+++ b/docs/light.md
@@ -26,7 +26,8 @@ The table below shows how the different features within this `exposes` entry are
       "adaptive_lighting": {
         "only_when_on": true,
         "transition": 0.5
-      }
+      },
+      "request_brightness": false
     }
   }
 }

--- a/src/converters/light.ts
+++ b/src/converters/light.ts
@@ -78,9 +78,7 @@ export class LightCreator implements ServiceCreator {
     let requestBrightness = false;
     let adaptiveLightingConfig: AdaptiveLightingConfig | undefined = undefined;
     if (isLightConfig(converterConfig)) {
-      if (converterConfig.request_brightness === true) {
-        requestBrightness = true;
-      }
+      requestBrightness = !!converterConfig.request_brightness;
       if (isAdaptiveLightingConfig(converterConfig.adaptive_lighting)) {
         adaptiveLightingConfig = converterConfig.adaptive_lighting;
       } else if (converterConfig.adaptive_lighting === true) {

--- a/test/light.spec.ts
+++ b/test/light.spec.ts
@@ -181,7 +181,7 @@ describe('Light', () => {
         newHarness.checkCreationExpectations();
         newHarness.checkHasMainCharacteristics();
 
-        newHarness.checkExpectedGetableKeys(['state', 'brightness', 'color_temp', 'color']);
+        newHarness.checkExpectedGetableKeys(['state', 'color_temp', 'color']);
 
         // Expect range of color temperature to be configured
         lightbulb.checkCharacteristicPropertiesHaveBeenSet('color_temp', {
@@ -507,7 +507,7 @@ describe('Light', () => {
         newHarness.checkCreationExpectations();
         newHarness.checkHasMainCharacteristics();
 
-        newHarness.checkExpectedGetableKeys(['state', 'brightness', 'color_temp', 'color']);
+        newHarness.checkExpectedGetableKeys(['state', 'color_temp', 'color']);
 
         // Expect range of color temperature to be configured
         lightbulb.checkCharacteristicPropertiesHaveBeenSet('color_temp', {
@@ -557,7 +557,7 @@ describe('Light', () => {
     });
   });
 
-  describe('Hue White Single bulb B22', () => {
+  describe('Hue White Single bulb B22 (allow request brightness)', () => {
     // Shared "state"
     let deviceExposes: ExposesEntry[] = [];
     let harness: ServiceHandlersTestHarness;
@@ -571,6 +571,10 @@ describe('Light', () => {
 
         // Check service creation
         const newHarness = new ServiceHandlersTestHarness();
+
+        // Enable adaptive lighting to check if it will be ignored (as this device does not have a color temperature)
+        newHarness.addConverterConfiguration('light', { request_brightness: true });
+
         newHarness
           .getOrAddHandler(hap.Service.Lightbulb)
           .addExpectedCharacteristic('state', hap.Characteristic.On, true)
@@ -687,7 +691,7 @@ describe('Light', () => {
         newHarness.checkCreationExpectations();
         newHarness.checkHasMainCharacteristics();
 
-        newHarness.checkExpectedGetableKeys(['state', 'brightness', 'color_temp', 'color']);
+        newHarness.checkExpectedGetableKeys(['state', 'color_temp', 'color']);
 
         // Expect range of color temperature to be configured
         lightbulb.checkCharacteristicPropertiesHaveBeenSet('color_temp', {
@@ -829,7 +833,7 @@ describe('Light', () => {
         newHarness.checkCreationExpectations();
         newHarness.checkHasMainCharacteristics();
 
-        newHarness.checkExpectedGetableKeys(['state', 'brightness']);
+        newHarness.checkExpectedGetableKeys(['state']);
         harness = newHarness;
       }
 
@@ -885,7 +889,7 @@ describe('Light', () => {
         newHarness.checkCreationExpectations();
         newHarness.checkHasMainCharacteristics();
 
-        newHarness.checkExpectedGetableKeys(['state', 'brightness', 'color_temp']);
+        newHarness.checkExpectedGetableKeys(['state', 'color_temp']);
 
         // Expect range of color temperature to be configured
         lightbulb.checkCharacteristicPropertiesHaveBeenSet('color_temp', {


### PR DESCRIPTION
Should prevent issue mentioned in #882

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added `request_brightness` configuration option for light converters.
	- Enhanced light sensor compatibility with Zigbee2MQTT v2.

- **Documentation**
	- Updated documentation to explain new `request_brightness` option.
	- Clarified default brightness request behavior.

- **Bug Fixes**
	- Improved light sensor functionality when `illuminance_lux` is unavailable.
	- Prevented potential issues with brightness requests when light is off.

- **Tests**
	- Adjusted test cases to reflect changes in brightness handling and expected device characteristics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->