### PR TITLE
Prevent TypeError when handling JSON availability payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Since version 1.0.0, we try to follow the [Semantic Versioning](https://semver.o
 
 - For numeric characteristics that have a range set, the range is automatically updated if an out of range value is received from Zigbee2MQTT.
 
+### Fixed
+
+- Processing JSON availability payload should not result in a TypeError anymore.
+
 ## [1.11.0-beta.7] - 2025-01-04
 
 ### Changed

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -407,9 +407,9 @@ export class Zigbee2mqttPlatform implements DynamicPlatformPlugin {
     // Check if payload is a JSON object or a plain string
     let isAvailable = false;
     if (statePayload.includes('{')) {
-      const state = JSON.parse(statePayload).availability;
-      if ('state' in state) {
-        isAvailable = state.state === 'online';
+      const json = JSON.parse(statePayload);
+      if (json !== undefined && 'availability' in json && json.availability !== undefined && 'state' in json.availability) {
+        isAvailable = json.availability.state === 'online';
       }
     } else {
       isAvailable = statePayload === 'online';


### PR DESCRIPTION
Should prevent the following error from occurring and crashing the plug-in:
```
TypeError: Cannot use 'in' operator to search for 'state' in undefined
    at Zigbee2mqttPlatform.handleDeviceAvailability (/usr/local/lib/node_modules/homebridge-z2m/src/platform.ts:411:18)
    at Zigbee2mqttPlatform.onMessage (/usr/local/lib/node_modules/homebridge-z2m/src/platform.ts:296:14)
    at MqttClient.emit (node:events:524:28)
    at handlePublish (/usr/local/lib/node_modules/homebridge-z2m/node_modules/mqtt/src/lib/handlers/publish.ts:172:11)
    at handle (/usr/local/lib/node_modules/homebridge-z2m/node_modules/mqtt/src/lib/handlers/index.ts:31:17)
    at work (/usr/local/lib/node_modules/homebridge-z2m/node_modules/mqtt/src/lib/client.ts:779:17)
    at processTicksAndRejections (node:internal/process/task_queues:85:11)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved TypeError when processing JSON availability payload.
  - Improved light sensor compatibility with Zigbee2MQTT v2 by using `illuminance` property when `illuminance_lux` is unavailable.
  - Enhanced error handling for device availability and update methods.

- **Configuration**
  - Added option to modify brightness request behavior for lights when off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->