### PR TITLE
Update tsconfig and dependencies for homebridge 2.0.0-beta.68 compatibility

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,16 @@ module.exports = {
   setupFilesAfterEnv: ['jest-chain'],
   coverageReporters: ['json', 'lcov', 'text', 'clover'],
   collectCoverageFrom: ['src/**/*.ts', '!src/docgen/*.ts'],
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        diagnostics: {
+          ignoreCodes: [151002],
+        },
+      },
+    ],
+  },
   reporters: [
     'default',
     [

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-sonarjs": "^3.0.1",
         "globals": "^16.0.0",
-        "homebridge": "^2.0.0-beta.23",
+        "homebridge": "^2.0.0-beta.68",
         "jest": "^30.2.0",
         "jest-chain": "^1.1.6",
         "jest-each": "^30.0.2",
@@ -765,36 +765,32 @@
       }
     },
     "node_modules/@homebridge/ciao": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.1.tgz",
-      "integrity": "sha512-87tQCBNNnTymlbg8pKlQjRsk7a5uuqhWBpCbUriVYUebz3voJkLbbTmp0TQg7Sa6Jnpk/Uo6LA8zAOy2sbK9bw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.4.tgz",
+      "integrity": "sha512-qK6ZgGx0wwOubq/MY6eTbhApQHBUQCvCOsTYpQE01uLvfA2/Prm6egySHlZouKaina1RPuDwfLhCmsRCxwHj3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.6",
+        "debug": "^4.4.1",
         "fast-deep-equal": "^3.1.3",
         "source-map-support": "^0.5.21",
-        "tslib": "^2.6.3"
+        "tslib": "^2.8.1"
       },
       "bin": {
         "ciao-bcs": "lib/bonjour-conformance-testing.js"
-      },
-      "engines": {
-        "node": "^18 || ^20 || ^22"
       }
     },
     "node_modules/@homebridge/dbus-native": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.6.0.tgz",
-      "integrity": "sha512-xObqQeYHTXmt6wsfj10+krTo4xbzR9BgUfX2aQ+edDC9nc4ojfzLScfXCh3zluAm6UCowKw+AFfXn6WLWUOPkg==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.2.tgz",
+      "integrity": "sha512-BNVe6YNxiy5x/E5/ZXDIWMD6Njv9cjW59PM/1CMpYe0jLAJ8pJN+Tq/JhVs3gXwmTavz2S86/sspmHquChet8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@homebridge/long": "^5.2.1",
-        "@homebridge/put": "^0.0.8",
         "event-stream": "^4.0.1",
         "hexy": "^0.3.5",
-        "minimist": "^1.2.6",
+        "long": "^5.3.2",
+        "minimist": "^1.2.8",
         "safe-buffer": "^5.1.2",
         "xml2js": "^0.6.2"
       },
@@ -802,21 +798,26 @@
         "dbus2js": "bin/dbus2js.js"
       }
     },
-    "node_modules/@homebridge/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@homebridge/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-i5Df8R63XNPCn+Nj1OgAoRdw9e+jHUQb3CNUbvJneI2iu3j4+OtzQj+5PA1Ce+747NR1SPqZSvyvD483dOT3AA==",
+    "node_modules/@homebridge/hap-nodejs": {
+      "version": "2.0.3-beta.0",
+      "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.0.3-beta.0.tgz",
+      "integrity": "sha512-Fpta5FD+OejWfWY64c4jVHzPshfc6SlFlhB1GqW3wY4ZorB8ZbbfRu8M4aR3/JDuRcg7xhiIeGGLNSsnkFxJdg==",
       "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@homebridge/put": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@homebridge/put/-/put-0.0.8.tgz",
-      "integrity": "sha512-mwxLHHqKebOmOSU0tsPEWQSBHGApPhuaqtNpCe7U+AMdsduweANiu64E9SXXUtdpyTjsOpgSMLhD1+kbLHD2gA==",
-      "dev": true,
-      "license": "MIT/X11",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@homebridge/ciao": "^1.3.4",
+        "@homebridge/dbus-native": "^0.7.2",
+        "bonjour-hap": "^3.9.1",
+        "debug": "^4.4.3",
+        "fast-srp-hap": "^2.0.4",
+        "futoin-hkdf": "^1.5.3",
+        "node-persist": "^0.0.12",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.8.1",
+        "tweetnacl": "^1.0.3"
+      },
       "engines": {
-        "node": ">=0.3.0"
+        "node": "^20 || ^22 || ^24"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1893,6 +1894,96 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@matter/general": {
+      "version": "0.16.0-alpha.0-20251228-8b11eb535",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.16.0-alpha.0-20251228-8b11eb535.tgz",
+      "integrity": "sha512-zoPT4LAutfbskFCKiKmQYumqLVTNBWf2NCP+hFWLPkh+yOhxe49GcMYe+JGc8BJTKLjlHn/Nlamv36Ok7jxzjQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^2.0.1"
+      }
+    },
+    "node_modules/@matter/main": {
+      "version": "0.16.0-alpha.0-20251228-8b11eb535",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.16.0-alpha.0-20251228-8b11eb535.tgz",
+      "integrity": "sha512-Db450KfkFwVoJ3is30ZuRlMdjyMK9AL012h4WSS7ABFMJGR+AT7dVHWPVpeN9ndiY8/DOwrfpACqZjIUCvgJcA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/model": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/node": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/protocol": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/types": "0.16.0-alpha.0-20251228-8b11eb535"
+      },
+      "optionalDependencies": {
+        "@matter/nodejs": "0.16.0-alpha.0-20251228-8b11eb535"
+      }
+    },
+    "node_modules/@matter/model": {
+      "version": "0.16.0-alpha.0-20251228-8b11eb535",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.16.0-alpha.0-20251228-8b11eb535.tgz",
+      "integrity": "sha512-w5DcVF6AIxNaexLhQsay3vH+tYfjUSD3K1pbR6Zpdijjq/al/smkR6scBnte6iUWLcTg6eb9wF4kN02e3ZJP7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.16.0-alpha.0-20251228-8b11eb535"
+      }
+    },
+    "node_modules/@matter/node": {
+      "version": "0.16.0-alpha.0-20251228-8b11eb535",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.16.0-alpha.0-20251228-8b11eb535.tgz",
+      "integrity": "sha512-IleJKZlFzetaHQzDBdte1yja2oS/bT8ESqDo2dcBRvJSaYYkLjTN+awAstsSDpyKKPSsv84iJtcok1oVC1jJ0w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/model": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/protocol": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/types": "0.16.0-alpha.0-20251228-8b11eb535"
+      }
+    },
+    "node_modules/@matter/nodejs": {
+      "version": "0.16.0-alpha.0-20251228-8b11eb535",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.16.0-alpha.0-20251228-8b11eb535.tgz",
+      "integrity": "sha512-n0b6iJea3nsLYAJBhC/6GIjU8KopShVAug0ppa6YkHnOJOxVCyIH6jWTIjS83rPKde+7rBPcPqgn3DrxWSwJlw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@matter/general": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/node": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/protocol": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/types": "0.16.0-alpha.0-20251228-8b11eb535"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.13.0"
+      }
+    },
+    "node_modules/@matter/protocol": {
+      "version": "0.16.0-alpha.0-20251228-8b11eb535",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.16.0-alpha.0-20251228-8b11eb535.tgz",
+      "integrity": "sha512-au//onyIrCJbHXQwB414BQErDypW6dZ5U2iNufwgGtmxZ1DTTGMB4MA8DKC0betaW+VpZJ9jy+wf1kqqdCOQCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/model": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/types": "0.16.0-alpha.0-20251228-8b11eb535"
+      }
+    },
+    "node_modules/@matter/types": {
+      "version": "0.16.0-alpha.0-20251228-8b11eb535",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.16.0-alpha.0-20251228-8b11eb535.tgz",
+      "integrity": "sha512-ihsQEYvshH/2t5OgMrCiUfUZBGvaFPP27maF/LSCkOpcwHEOl1dICHvaO5nsFEr27cBuvTyrx7+ycl4mZsWANg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@matter/general": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/model": "0.16.0-alpha.0-20251228-8b11eb535"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1903,6 +1994,35 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodeutils/defaults-deep": {
@@ -3080,6 +3200,7 @@
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
       "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "is-array-buffer": "^3.0.5"
@@ -3124,6 +3245,7 @@
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -3296,9 +3418,9 @@
       }
     },
     "node_modules/bonjour-hap": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.9.0.tgz",
-      "integrity": "sha512-g/25iC9U3vYCwR8NvspPJhsl8kNgVSsXPbgAFO/+Gm0x6kn33XCL6CMvg79ZViAAo0NZRHqa5VR52eUw1zE2IA==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.9.1.tgz",
+      "integrity": "sha512-ubpbZSBwRyAx2+j5RLKFO+QuRvB02s+7rinC0rQzICx9hEc0zryjRz56Rr9lxoW7UkE/mnZ4rP4mnTCF4/iUkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3512,6 +3634,7 @@
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
@@ -3526,10 +3649,11 @@
       }
     },
     "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
-      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -3539,13 +3663,14 @@
       }
     },
     "node_modules/call-bound": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3769,13 +3894,13 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/commander": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
-      "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/commist": {
@@ -3854,9 +3979,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3966,6 +4091,7 @@
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -3995,6 +4121,7 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -4081,6 +4208,7 @@
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -4163,6 +4291,7 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -4172,6 +4301,7 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -4198,10 +4328,11 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -4841,12 +4972,19 @@
       "license": "ISC"
     },
     "node_modules/for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "is-callable": "^1.1.3"
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/foreground-child": {
@@ -4885,9 +5023,9 @@
       "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
+      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4924,6 +5062,7 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4939,6 +5078,7 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4984,17 +5124,18 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
@@ -5021,6 +5162,7 @@
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -5141,6 +5283,7 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5175,33 +5318,15 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/hap-nodejs": {
-      "version": "1.1.1-beta.7",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-1.1.1-beta.7.tgz",
-      "integrity": "sha512-ti/sg3KLV1AKwjJWymci76lIxf9Brya6oRBJT6Xs2PeDw3/PnRuXaSYvC62XRcWfiE670otye2JyUnT9ZVpSow==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@homebridge/ciao": "^1.3.1",
-        "@homebridge/dbus-native": "^0.6.0",
-        "bonjour-hap": "^3.8.0",
-        "debug": "^4.3.7",
-        "fast-srp-hap": "^2.0.4",
-        "futoin-hkdf": "^1.5.3",
-        "node-persist": "^0.0.12",
-        "source-map-support": "^0.5.21",
-        "tslib": "^2.7.0",
-        "tweetnacl": "^1.0.3"
-      },
-      "engines": {
-        "node": "^18 || ^20 || ^22"
-      }
-    },
     "node_modules/has-bigints": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5220,6 +5345,7 @@
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -5232,6 +5358,7 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5244,6 +5371,7 @@
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -5259,6 +5387,7 @@
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -5285,31 +5414,32 @@
       }
     },
     "node_modules/homebridge": {
-      "version": "2.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-2.0.0-beta.27.tgz",
-      "integrity": "sha512-SM/kxoUgu8ep8oT5+KTZfpCwTAnpPvXQRVPkE39TAjo3crh/KKFtOt3uyueDOmMr/wYTMB4u9Oin6L5Kmp5mdQ==",
+      "version": "2.0.0-beta.68",
+      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-2.0.0-beta.68.tgz",
+      "integrity": "sha512-nsCSZaJ+hqcpUQ94Rnx3nhiTxUZf8IuPBCx1UYwedMq2qssD1G7QtBbu4TUUAtSKN+tyMvKzlf4zA+SNz0rKqA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "chalk": "5.4.1",
-        "commander": "13.0.0",
-        "fs-extra": "11.3.0",
-        "hap-nodejs": "1.1.1-beta.7",
+        "@homebridge/hap-nodejs": "2.0.3-beta.0",
+        "@matter/main": "0.16.0-alpha.0-20251228-8b11eb535",
+        "chalk": "5.6.2",
+        "commander": "14.0.2",
+        "fs-extra": "11.3.3",
         "qrcode-terminal": "0.12.0",
-        "semver": "7.6.3",
+        "semver": "7.7.3",
         "source-map-support": "0.5.21"
       },
       "bin": {
         "homebridge": "bin/homebridge.js"
       },
       "engines": {
-        "node": "^18.15.0 || ^20.7.0 || ^22"
+        "node": "^20.7.0 || ^22 || ^24"
       }
     },
     "node_modules/homebridge/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5317,19 +5447,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/homebridge/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/html-escaper": {
@@ -5526,6 +5643,7 @@
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
       "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "hasown": "^2.0.2",
@@ -5574,6 +5692,7 @@
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
       "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -5597,6 +5716,7 @@
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
       "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.2"
       },
@@ -5620,12 +5740,13 @@
       }
     },
     "node_modules/is-boolean-object": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
-      "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.2",
+        "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -5640,6 +5761,7 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5652,6 +5774,7 @@
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
       "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
@@ -5752,6 +5875,7 @@
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5773,6 +5897,7 @@
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
       "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
@@ -5789,6 +5914,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "gopd": "^1.2.0",
@@ -5807,6 +5933,7 @@
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
       "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5819,6 +5946,7 @@
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
       "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
       },
@@ -5855,6 +5983,7 @@
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
       "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
@@ -5871,6 +6000,7 @@
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
       "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-symbols": "^1.1.0",
@@ -5900,6 +6030,7 @@
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
       "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5908,13 +6039,14 @@
       }
     },
     "node_modules/is-weakset": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
-      "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "get-intrinsic": "^1.2.4"
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5942,7 +6074,8 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6924,9 +7057,9 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7060,6 +7193,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/lru-cache": {
       "version": "11.2.4",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
@@ -7123,6 +7263,7 @@
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -7637,10 +7778,11 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -7670,6 +7812,7 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -7679,6 +7822,7 @@
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -8115,10 +8259,11 @@
       }
     },
     "node_modules/possible-typed-array-names": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -8376,14 +8521,17 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
-      "integrity": "sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
         "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
         "set-function-name": "^2.0.2"
       },
       "engines": {
@@ -8648,6 +8796,7 @@
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -8667,11 +8816,11 @@
       "dev": true
     },
     "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
+      "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/scslre": {
       "version": "0.3.0",
@@ -8703,6 +8852,7 @@
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -8720,6 +8870,7 @@
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -8756,6 +8907,7 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -8775,6 +8927,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -8791,6 +8944,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -8809,6 +8963,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -9693,6 +9848,7 @@
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
       "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.1.0",
         "is-boolean-object": "^1.2.1",
@@ -9712,6 +9868,7 @@
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
       "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-map": "^2.0.3",
         "is-set": "^2.0.3",
@@ -9726,15 +9883,17 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
-      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "for-each": "^0.3.3",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },
@@ -10694,43 +10853,48 @@
       }
     },
     "@homebridge/ciao": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.1.tgz",
-      "integrity": "sha512-87tQCBNNnTymlbg8pKlQjRsk7a5uuqhWBpCbUriVYUebz3voJkLbbTmp0TQg7Sa6Jnpk/Uo6LA8zAOy2sbK9bw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.4.tgz",
+      "integrity": "sha512-qK6ZgGx0wwOubq/MY6eTbhApQHBUQCvCOsTYpQE01uLvfA2/Prm6egySHlZouKaina1RPuDwfLhCmsRCxwHj3Q==",
       "dev": true,
       "requires": {
-        "debug": "^4.3.6",
+        "debug": "^4.4.1",
         "fast-deep-equal": "^3.1.3",
         "source-map-support": "^0.5.21",
-        "tslib": "^2.6.3"
+        "tslib": "^2.8.1"
       }
     },
     "@homebridge/dbus-native": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.6.0.tgz",
-      "integrity": "sha512-xObqQeYHTXmt6wsfj10+krTo4xbzR9BgUfX2aQ+edDC9nc4ojfzLScfXCh3zluAm6UCowKw+AFfXn6WLWUOPkg==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.2.tgz",
+      "integrity": "sha512-BNVe6YNxiy5x/E5/ZXDIWMD6Njv9cjW59PM/1CMpYe0jLAJ8pJN+Tq/JhVs3gXwmTavz2S86/sspmHquChet8A==",
       "dev": true,
       "requires": {
-        "@homebridge/long": "^5.2.1",
-        "@homebridge/put": "^0.0.8",
         "event-stream": "^4.0.1",
         "hexy": "^0.3.5",
-        "minimist": "^1.2.6",
+        "long": "^5.3.2",
+        "minimist": "^1.2.8",
         "safe-buffer": "^5.1.2",
         "xml2js": "^0.6.2"
       }
     },
-    "@homebridge/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@homebridge/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-i5Df8R63XNPCn+Nj1OgAoRdw9e+jHUQb3CNUbvJneI2iu3j4+OtzQj+5PA1Ce+747NR1SPqZSvyvD483dOT3AA==",
-      "dev": true
-    },
-    "@homebridge/put": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@homebridge/put/-/put-0.0.8.tgz",
-      "integrity": "sha512-mwxLHHqKebOmOSU0tsPEWQSBHGApPhuaqtNpCe7U+AMdsduweANiu64E9SXXUtdpyTjsOpgSMLhD1+kbLHD2gA==",
-      "dev": true
+    "@homebridge/hap-nodejs": {
+      "version": "2.0.3-beta.0",
+      "resolved": "https://registry.npmjs.org/@homebridge/hap-nodejs/-/hap-nodejs-2.0.3-beta.0.tgz",
+      "integrity": "sha512-Fpta5FD+OejWfWY64c4jVHzPshfc6SlFlhB1GqW3wY4ZorB8ZbbfRu8M4aR3/JDuRcg7xhiIeGGLNSsnkFxJdg==",
+      "dev": true,
+      "requires": {
+        "@homebridge/ciao": "^1.3.4",
+        "@homebridge/dbus-native": "^0.7.2",
+        "bonjour-hap": "^3.9.1",
+        "debug": "^4.4.3",
+        "fast-srp-hap": "^2.0.4",
+        "futoin-hkdf": "^1.5.3",
+        "node-persist": "^0.0.12",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.8.1",
+        "tweetnacl": "^1.0.3"
+      }
     },
     "@humanfs/core": {
       "version": "0.19.1",
@@ -11490,6 +11654,84 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "dev": true
     },
+    "@matter/general": {
+      "version": "0.16.0-alpha.0-20251228-8b11eb535",
+      "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.16.0-alpha.0-20251228-8b11eb535.tgz",
+      "integrity": "sha512-zoPT4LAutfbskFCKiKmQYumqLVTNBWf2NCP+hFWLPkh+yOhxe49GcMYe+JGc8BJTKLjlHn/Nlamv36Ok7jxzjQ==",
+      "dev": true,
+      "requires": {
+        "@noble/curves": "^2.0.1"
+      }
+    },
+    "@matter/main": {
+      "version": "0.16.0-alpha.0-20251228-8b11eb535",
+      "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.16.0-alpha.0-20251228-8b11eb535.tgz",
+      "integrity": "sha512-Db450KfkFwVoJ3is30ZuRlMdjyMK9AL012h4WSS7ABFMJGR+AT7dVHWPVpeN9ndiY8/DOwrfpACqZjIUCvgJcA==",
+      "dev": true,
+      "requires": {
+        "@matter/general": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/model": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/node": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/nodejs": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/protocol": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/types": "0.16.0-alpha.0-20251228-8b11eb535"
+      }
+    },
+    "@matter/model": {
+      "version": "0.16.0-alpha.0-20251228-8b11eb535",
+      "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.16.0-alpha.0-20251228-8b11eb535.tgz",
+      "integrity": "sha512-w5DcVF6AIxNaexLhQsay3vH+tYfjUSD3K1pbR6Zpdijjq/al/smkR6scBnte6iUWLcTg6eb9wF4kN02e3ZJP7A==",
+      "dev": true,
+      "requires": {
+        "@matter/general": "0.16.0-alpha.0-20251228-8b11eb535"
+      }
+    },
+    "@matter/node": {
+      "version": "0.16.0-alpha.0-20251228-8b11eb535",
+      "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.16.0-alpha.0-20251228-8b11eb535.tgz",
+      "integrity": "sha512-IleJKZlFzetaHQzDBdte1yja2oS/bT8ESqDo2dcBRvJSaYYkLjTN+awAstsSDpyKKPSsv84iJtcok1oVC1jJ0w==",
+      "dev": true,
+      "requires": {
+        "@matter/general": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/model": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/protocol": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/types": "0.16.0-alpha.0-20251228-8b11eb535"
+      }
+    },
+    "@matter/nodejs": {
+      "version": "0.16.0-alpha.0-20251228-8b11eb535",
+      "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.16.0-alpha.0-20251228-8b11eb535.tgz",
+      "integrity": "sha512-n0b6iJea3nsLYAJBhC/6GIjU8KopShVAug0ppa6YkHnOJOxVCyIH6jWTIjS83rPKde+7rBPcPqgn3DrxWSwJlw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@matter/general": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/node": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/protocol": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/types": "0.16.0-alpha.0-20251228-8b11eb535"
+      }
+    },
+    "@matter/protocol": {
+      "version": "0.16.0-alpha.0-20251228-8b11eb535",
+      "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.16.0-alpha.0-20251228-8b11eb535.tgz",
+      "integrity": "sha512-au//onyIrCJbHXQwB414BQErDypW6dZ5U2iNufwgGtmxZ1DTTGMB4MA8DKC0betaW+VpZJ9jy+wf1kqqdCOQCQ==",
+      "dev": true,
+      "requires": {
+        "@matter/general": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/model": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/types": "0.16.0-alpha.0-20251228-8b11eb535"
+      }
+    },
+    "@matter/types": {
+      "version": "0.16.0-alpha.0-20251228-8b11eb535",
+      "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.16.0-alpha.0-20251228-8b11eb535.tgz",
+      "integrity": "sha512-ihsQEYvshH/2t5OgMrCiUfUZBGvaFPP27maF/LSCkOpcwHEOl1dICHvaO5nsFEr27cBuvTyrx7+ycl4mZsWANg==",
+      "dev": true,
+      "requires": {
+        "@matter/general": "0.16.0-alpha.0-20251228-8b11eb535",
+        "@matter/model": "0.16.0-alpha.0-20251228-8b11eb535"
+      }
+    },
     "@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -11501,6 +11743,21 @@
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
       }
+    },
+    "@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "dev": true,
+      "requires": {
+        "@noble/hashes": "2.0.1"
+      }
+    },
+    "@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "dev": true
     },
     "@nodeutils/defaults-deep": {
       "version": "1.1.0",
@@ -12488,9 +12745,9 @@
       }
     },
     "bonjour-hap": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.9.0.tgz",
-      "integrity": "sha512-g/25iC9U3vYCwR8NvspPJhsl8kNgVSsXPbgAFO/+Gm0x6kn33XCL6CMvg79ZViAAo0NZRHqa5VR52eUw1zE2IA==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.9.1.tgz",
+      "integrity": "sha512-ubpbZSBwRyAx2+j5RLKFO+QuRvB02s+7rinC0rQzICx9hEc0zryjRz56Rr9lxoW7UkE/mnZ4rP4mnTCF4/iUkg==",
       "dev": true,
       "requires": {
         "array-flatten": "^3.0.0",
@@ -12635,9 +12892,9 @@
       }
     },
     "call-bind-apply-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
-      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "requires": {
         "es-errors": "^1.3.0",
@@ -12645,13 +12902,13 @@
       }
     },
     "call-bound": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
       "requires": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       }
     },
     "callsites": {
@@ -12800,9 +13057,9 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "commander": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.0.0.tgz",
-      "integrity": "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
       "dev": true
     },
     "commist": {
@@ -12869,9 +13126,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "requires": {
         "ms": "^2.1.3"
       }
@@ -13110,9 +13367,9 @@
       }
     },
     "es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "requires": {
         "es-errors": "^1.3.0"
@@ -13542,12 +13799,12 @@
       "dev": true
     },
     "for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.3"
+        "is-callable": "^1.2.7"
       }
     },
     "foreground-child": {
@@ -13575,9 +13832,9 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
+      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
@@ -13641,17 +13898,17 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "requires": {
-        "call-bind-apply-helpers": "^1.0.1",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
@@ -13778,28 +14035,10 @@
         "wordwrap": "^1.0.0"
       }
     },
-    "hap-nodejs": {
-      "version": "1.1.1-beta.7",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-1.1.1-beta.7.tgz",
-      "integrity": "sha512-ti/sg3KLV1AKwjJWymci76lIxf9Brya6oRBJT6Xs2PeDw3/PnRuXaSYvC62XRcWfiE670otye2JyUnT9ZVpSow==",
-      "dev": true,
-      "requires": {
-        "@homebridge/ciao": "^1.3.1",
-        "@homebridge/dbus-native": "^0.6.0",
-        "bonjour-hap": "^3.8.0",
-        "debug": "^4.3.7",
-        "fast-srp-hap": "^2.0.4",
-        "futoin-hkdf": "^1.5.3",
-        "node-persist": "^0.0.12",
-        "source-map-support": "^0.5.21",
-        "tslib": "^2.7.0",
-        "tweetnacl": "^1.0.3"
-      }
-    },
     "has-bigints": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true
     },
     "has-flag": {
@@ -13853,30 +14092,25 @@
       "dev": true
     },
     "homebridge": {
-      "version": "2.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-2.0.0-beta.27.tgz",
-      "integrity": "sha512-SM/kxoUgu8ep8oT5+KTZfpCwTAnpPvXQRVPkE39TAjo3crh/KKFtOt3uyueDOmMr/wYTMB4u9Oin6L5Kmp5mdQ==",
+      "version": "2.0.0-beta.68",
+      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-2.0.0-beta.68.tgz",
+      "integrity": "sha512-nsCSZaJ+hqcpUQ94Rnx3nhiTxUZf8IuPBCx1UYwedMq2qssD1G7QtBbu4TUUAtSKN+tyMvKzlf4zA+SNz0rKqA==",
       "dev": true,
       "requires": {
-        "chalk": "5.4.1",
-        "commander": "13.0.0",
-        "fs-extra": "11.3.0",
-        "hap-nodejs": "1.1.1-beta.7",
+        "@homebridge/hap-nodejs": "2.0.3-beta.0",
+        "@matter/main": "0.16.0-alpha.0-20251228-8b11eb535",
+        "chalk": "5.6.2",
+        "commander": "14.0.2",
+        "fs-extra": "11.3.3",
         "qrcode-terminal": "0.12.0",
-        "semver": "7.6.3",
+        "semver": "7.7.3",
         "source-map-support": "0.5.21"
       },
       "dependencies": {
         "chalk": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-          "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+          "version": "5.6.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+          "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
           "dev": true
         }
       }
@@ -14079,12 +14313,12 @@
       }
     },
     "is-boolean-object": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
-      "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
       "requires": {
-        "call-bound": "^1.0.2",
+        "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
       }
     },
@@ -14250,13 +14484,13 @@
       "dev": true
     },
     "is-weakset": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
-      "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.7",
-        "get-intrinsic": "^1.2.4"
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       }
     },
     "is-wsl": {
@@ -15029,9 +15263,9 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
@@ -15141,6 +15375,12 @@
         "is-unicode-supported": "^2.0.0",
         "yoctocolors": "^2.1.1"
       }
+    },
+    "long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true
     },
     "lru-cache": {
       "version": "11.2.4",
@@ -15551,9 +15791,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true
     },
     "object-is": {
@@ -15891,9 +16131,9 @@
       }
     },
     "possible-typed-array-names": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true
     },
     "prelude-ls": {
@@ -16078,14 +16318,16 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
-      "integrity": "sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
         "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
         "set-function-name": "^2.0.2"
       }
     },
@@ -16278,9 +16520,9 @@
       "dev": true
     },
     "sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
+      "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
       "dev": true
     },
     "scslre": {
@@ -16992,15 +17234,16 @@
       }
     },
     "which-typed-array": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
-      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
       "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "for-each": "^0.3.3",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-sonarjs": "^3.0.1",
     "globals": "^16.0.0",
-    "homebridge": "^2.0.0-beta.23",
+    "homebridge": "^2.0.0-beta.68",
     "jest": "^30.2.0",
     "jest-chain": "^1.1.6",
     "jest-each": "^30.0.2",

--- a/src/docgen/docgen.ts
+++ b/src/docgen/docgen.ts
@@ -8,9 +8,9 @@ import { Definition, Expose, prepareDefinition } from 'zigbee-herdsman-converter
 import { BasicServiceCreatorManager } from '../converters/creators';
 import { DocsAccessory } from './docs_accessory';
 import { ExposesEntry } from '../z2mModels';
-import * as hapNodeJs from 'hap-nodejs';
+import * as hapNodeJs from '@homebridge/hap-nodejs';
 import { setHap } from '../hap';
-import { Service, WithUUID } from 'hap-nodejs';
+import { Service, WithUUID } from '@homebridge/hap-nodejs';
 import { version_herdsman_converters, version_zigbee2mqtt } from './versions';
 
 // Load all definitions from device files (zigbee-herdsman-converters no longer exports definitions directly)

--- a/test/action.spec.ts
+++ b/test/action.spec.ts
@@ -1,7 +1,7 @@
 import { resetAllWhenMocks, verifyAllWhenMocksCalled } from 'jest-when';
 import { hap, setHap } from '../src/hap';
 import { ExposesEntry } from '../src/z2mModels';
-import * as hapNodeJs from 'hap-nodejs';
+import * as hapNodeJs from '@homebridge/hap-nodejs';
 import 'jest-chain';
 import { loadExposesFromFile, ServiceHandlersTestHarness } from './testHelpers';
 import { sanitizeAndFilterExposesEntries } from '../src/helpers';

--- a/test/air_quality.spec.ts
+++ b/test/air_quality.spec.ts
@@ -1,10 +1,10 @@
 import { resetAllWhenMocks, verifyAllWhenMocksCalled } from 'jest-when';
 import { ExposesEntry } from '../src/z2mModels';
 import { setHap, hap } from '../src/hap';
-import * as hapNodeJs from 'hap-nodejs';
+import * as hapNodeJs from '@homebridge/hap-nodejs';
 import 'jest-chain';
 import { loadExposesFromFile, ServiceHandlersTestHarness } from './testHelpers';
-import { Characteristic, CharacteristicValue, WithUUID } from 'hap-nodejs';
+import { Characteristic, CharacteristicValue, WithUUID } from '@homebridge/hap-nodejs';
 
 describe('Air Quality Sensor', () => {
   beforeAll(() => {

--- a/test/basic_sensors.spec.ts
+++ b/test/basic_sensors.spec.ts
@@ -1,7 +1,7 @@
 import { resetAllWhenMocks, verifyAllWhenMocksCalled } from 'jest-when';
 import { ExposesEntry } from '../src/z2mModels';
 import { setHap, hap } from '../src/hap';
-import * as hapNodeJs from 'hap-nodejs';
+import * as hapNodeJs from '@homebridge/hap-nodejs';
 import 'jest-chain';
 import { loadExposesFromFile, ServiceHandlersTestHarness } from './testHelpers';
 import { Characteristic, CharacteristicValue, WithUUID } from 'homebridge';

--- a/test/carbon_dioxide.spec.ts
+++ b/test/carbon_dioxide.spec.ts
@@ -1,7 +1,7 @@
 import { resetAllWhenMocks, verifyAllWhenMocksCalled } from 'jest-when';
 import { ExposesEntry } from '../src/z2mModels';
 import { setHap, hap } from '../src/hap';
-import * as hapNodeJs from 'hap-nodejs';
+import * as hapNodeJs from '@homebridge/hap-nodejs';
 import 'jest-chain';
 import { loadExposesFromFile, ServiceHandlersTestHarness } from './testHelpers';
 import { Characteristic, CharacteristicValue, WithUUID } from 'homebridge';

--- a/test/climate.spec.ts
+++ b/test/climate.spec.ts
@@ -1,7 +1,7 @@
 import { resetAllWhenMocks, verifyAllWhenMocksCalled } from 'jest-when';
 import { ExposesEntry } from '../src/z2mModels';
 import { setHap, hap } from '../src/hap';
-import * as hapNodeJs from 'hap-nodejs';
+import * as hapNodeJs from '@homebridge/hap-nodejs';
 import 'jest-chain';
 import { loadExposesFromFile, ServiceHandlersTestHarness } from './testHelpers';
 

--- a/test/configModels.spec.ts
+++ b/test/configModels.spec.ts
@@ -3,7 +3,7 @@ import 'jest-chain';
 import 'jest';
 import { isPluginConfiguration } from '../src/configModels';
 import { BasicServiceCreatorManager } from '../src/converters/creators';
-import * as hapNodeJs from 'hap-nodejs';
+import * as hapNodeJs from '@homebridge/hap-nodejs';
 import { setHap } from '../src/hap';
 
 /* eslint-disable-next-line @typescript-eslint/no-extraneous-class */

--- a/test/cover.spec.ts
+++ b/test/cover.spec.ts
@@ -1,7 +1,7 @@
 import { resetAllWhenMocks, verifyAllWhenMocksCalled } from 'jest-when';
 import { ExposesEntry } from '../src/z2mModels';
 import { setHap, hap } from '../src/hap';
-import * as hapNodeJs from 'hap-nodejs';
+import * as hapNodeJs from '@homebridge/hap-nodejs';
 import 'jest-chain';
 import { loadExposesFromFile, ServiceHandlersTestHarness } from './testHelpers';
 

--- a/test/light.spec.ts
+++ b/test/light.spec.ts
@@ -1,7 +1,7 @@
 import { resetAllWhenMocks, verifyAllWhenMocksCalled } from 'jest-when';
 import { ExposesEntry } from '../src/z2mModels';
 import { setHap, hap } from '../src/hap';
-import * as hapNodeJs from 'hap-nodejs';
+import * as hapNodeJs from '@homebridge/hap-nodejs';
 import 'jest-chain';
 import { loadExposesFromFile, ServiceHandlersTestHarness, testJsonDeviceListEntry } from './testHelpers';
 

--- a/test/lock.spec.ts
+++ b/test/lock.spec.ts
@@ -1,7 +1,7 @@
 import { resetAllWhenMocks, verifyAllWhenMocksCalled } from 'jest-when';
 import { ExposesEntry } from '../src/z2mModels';
 import { setHap, hap } from '../src/hap';
-import * as hapNodeJs from 'hap-nodejs';
+import * as hapNodeJs from '@homebridge/hap-nodejs';
 import 'jest-chain';
 import { loadExposesFromFile, ServiceHandlersTestHarness } from './testHelpers';
 import { Characteristic, CharacteristicValue, WithUUID } from 'homebridge';

--- a/test/switch.spec.ts
+++ b/test/switch.spec.ts
@@ -1,7 +1,7 @@
 import { resetAllWhenMocks, verifyAllWhenMocksCalled } from 'jest-when';
 import { ExposesEntry } from '../src/z2mModels';
 import { setHap, hap } from '../src/hap';
-import * as hapNodeJs from 'hap-nodejs';
+import * as hapNodeJs from '@homebridge/hap-nodejs';
 import 'jest-chain';
 import { loadExposesFromFile, ServiceHandlersTestHarness } from './testHelpers';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "lib": [
+      "DOM",
       "ES2022"
     ],
     "declaration": true,
@@ -12,6 +14,8 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
     "noImplicitAny": false,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true


### PR DESCRIPTION
- Update tsconfig.json to use nodenext module resolution with DOM lib
  (aligns with homebridge-plugin-template)
- Update hap-nodejs imports to use @homebridge/hap-nodejs
  (hap-nodejs is now scoped under @homebridge)
- Configure ts-jest to suppress hybrid module warning (151002)
- Bump homebridge devDependency to 2.0.0-beta.68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript configuration for improved module resolution and platform compatibility.
  * Adjusted Jest configuration to better handle TypeScript tests.
  * Bumped Homebridge devDependency to a newer beta release.
  * Migrated imports to the scoped Homebridge package namespace for consistency across source and test code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->