### PR TITLE
Migrate availability configuration to Zigbee2MQTT v2 format

### DIFF
--- a/src/configHelpers.ts
+++ b/src/configHelpers.ts
@@ -8,12 +8,10 @@ import { BasicLogger } from './logger';
  */
 export function isAvailabilityEnabledGlobally(config: Record<string, any>): boolean {
   if (typeof config.availability === 'object') {
-    // In zigbee2mqtt v3+, availability is always an object with 'enabled' property
     // Default to true if enabled is not explicitly set (for backward compatibility)
     return config?.availability?.enabled ?? true;
   }
 
-  // Check for new availability structure (availability.enabled)
   if (typeof config.availability === 'boolean') {
     return config.availability;
   }

--- a/src/configHelpers.ts
+++ b/src/configHelpers.ts
@@ -7,7 +7,7 @@ import { BasicLogger } from './logger';
  * @returns True if availability is configured
  */
 export function isAvailabilityEnabledGlobally(config: Record<string, any>): boolean {
-  const availabilityEnabled = config.availability || config.advanced?.availability_timeout;
+  const availabilityEnabled = config.availability?.enabled || config.advanced?.availability_timeout;
   if (!availabilityEnabled) {
     return false;
   }
@@ -77,6 +77,7 @@ function getAvailabilityFromDeviceConfigurations(config: Record<string, any>, lo
       }
     }
   }
+
   return result;
 }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -363,7 +363,7 @@ export class Zigbee2mqttPlatform implements DynamicPlatformPlugin {
       }
 
       // Check availability configuration
-      this.processAvailabilityConfig(info);
+      this.processAvailabilityConfig(info?.config ?? {});
     }
   }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -23,7 +23,7 @@ import {
   isDeviceListEntryForGroup,
 } from './z2mModels';
 import * as semver from 'semver';
-import { errorToString, getDiffFromArrays, parseBridgeOnlineState, sanitizeAccessoryName } from './helpers';
+import { errorToString, getDiffFromArrays, parseBridgeOnlineState, parseDeviceAvailability, sanitizeAccessoryName } from './helpers';
 import { BasicServiceCreatorManager } from './converters/creators';
 import { getAvailabilityConfigurationForDevices, isAvailabilityEnabledGlobally } from './configHelpers';
 import { BasicLogger } from './logger';
@@ -414,17 +414,7 @@ export class Zigbee2mqttPlatform implements DynamicPlatformPlugin {
   }
 
   private async handleDeviceAvailability(topic: string, statePayload: string) {
-    // Check if payload is a JSON object or a plain string
-    let isAvailable = false;
-    if (statePayload.includes('{')) {
-      const json = JSON.parse(statePayload);
-      if (json !== undefined) {
-        // {'state': 'online'} is the new format while {'availability': {'state': 'online'}} is the old one
-        isAvailable = json.state === 'online' || json.availability?.state === 'online';
-      }
-    } else {
-      isAvailable = statePayload === 'online';
-    }
+    const isAvailable = parseDeviceAvailability(statePayload);
     const deviceTopic = topic.slice(0, -1 * Zigbee2mqttPlatform.TOPIC_SUFFIX_AVAILABILITY.length);
     const accessory = this.accessories.find((acc) => acc.matchesIdentifier(deviceTopic));
     if (accessory) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -418,8 +418,9 @@ export class Zigbee2mqttPlatform implements DynamicPlatformPlugin {
     let isAvailable = false;
     if (statePayload.includes('{')) {
       const json = JSON.parse(statePayload);
-      if (json !== undefined && 'availability' in json && json.availability !== undefined && 'state' in json.availability) {
-        isAvailable = json.availability.state === 'online';
+      if (json !== undefined) {
+        // {'state': 'online'} is the new format while {'availability': {'state': 'online'}} is the old one
+        isAvailable = json.state === 'online' || json.availability?.state === 'online';
       }
     } else {
       isAvailable = statePayload === 'online';

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -30,7 +30,7 @@ import { BasicLogger } from './logger';
 import { ConfigurableLogger } from './configurableLogger';
 
 export class Zigbee2mqttPlatform implements DynamicPlatformPlugin {
-  private static readonly MIN_Z2M_VERSION = '1.17.0';
+  private static readonly MIN_Z2M_VERSION = '2.0.0';
   private static readonly TOPIC_BRIDGE = 'bridge/';
   private static readonly TOPIC_SUFFIX_AVAILABILITY = '/availability';
 

--- a/test/configHelpers.spec.ts
+++ b/test/configHelpers.spec.ts
@@ -34,24 +34,6 @@ describe('Zigbee2MQTT Config Helper functions', () => {
       };
       expect(isAvailabilityEnabledGlobally(config)).toBe(true);
     });
-    test('availability (simple) set to true with empty passlist', () => {
-      const config: object = {
-        availability: true,
-        advanced: {
-          availability_passlist: [],
-        },
-      };
-      expect(isAvailabilityEnabledGlobally(config)).toBe(true);
-    });
-    test('availability (simple) set to true with non-empty passlist', () => {
-      const config: object = {
-        availability: true,
-        advanced: {
-          availability_passlist: ['0x1234'],
-        },
-      };
-      expect(isAvailabilityEnabledGlobally(config)).toBe(false);
-    });
     test('availability (advanced) timeout set for active devices', () => {
       const config: object = {
         availability: {
@@ -81,7 +63,7 @@ describe('Zigbee2MQTT Config Helper functions', () => {
   });
 
   describe('getAvailabilityConfigurationForDevices', () => {
-    test('devices and pass list, block list ignored', () => {
+    test('devices with availability configuration (legacy passlist/blocklist no longer supported)', () => {
       const config = {
         devices: {
           device_a: {
@@ -95,6 +77,7 @@ describe('Zigbee2MQTT Config Helper functions', () => {
           },
         },
         advanced: {
+          // These legacy settings are ignored (removed in zigbee2mqtt v2)
           availability_passlist: ['device_d', 'device_e'],
           availability_whitelist: ['device_f'],
           availability_blocklist: ['device_g', 'device_h'],
@@ -102,33 +85,9 @@ describe('Zigbee2MQTT Config Helper functions', () => {
       };
 
       const result = getAvailabilityConfigurationForDevices(config);
-      const expect_enabled = ['device_a', 'device_d', 'device_e', 'device_f'].sort();
+      // Only device-specific config is used, legacy passlist/blocklist are ignored
+      const expect_enabled = ['device_a'].sort();
       const expect_disabled = ['device_b'].sort();
-      expect(result.enabled.sort()).toEqual(expect_enabled);
-      expect(result.disabled.sort()).toEqual(expect_disabled);
-    });
-    test('devices and block list, empty pass list', () => {
-      const config = {
-        devices: {
-          device_a: {
-            availability: false,
-          },
-          device_b: {
-            availability: true,
-          },
-          device_c: {
-            transition: 4,
-          },
-        },
-        advanced: {
-          availability_blocklist: ['device_d', 'device_e'],
-          availability_blacklist: ['device_f', 'device_g'],
-        },
-      };
-
-      const result = getAvailabilityConfigurationForDevices(config);
-      const expect_enabled = ['device_b'].sort();
-      const expect_disabled = ['device_a', 'device_d', 'device_e', 'device_f', 'device_g'].sort();
       expect(result.enabled.sort()).toEqual(expect_enabled);
       expect(result.disabled.sort()).toEqual(expect_disabled);
     });


### PR DESCRIPTION
Recently had couple issues with availability using `[1.11.0-beta.10]`, like devices suddenly became available but in reality they were not. I started debugging and spotted some potential problems, maybe due to structure changes in zigbee2mqtt. I've been using these change now for couple weeks in my local homebridge and working fine (with the latest zigbee2mqtt@2.7.2).

Could you please take a look and check if these make sense to merge in the project?

Detailed changes:

* previously passing `info.config` to `processAvailabilityConfig` rather than `info`. Checked the data and `config` should contain the right fields
* restructuring `isAvailabilityEnabledGlobally` in accordance to the simplified availability config, tried to keep backward compatibility
* removed passlist handling, that was removed from zigbee2mqtt (although this is not backward compatible with v1.* zigbee2mqtt)
* changed the tests
* changed parsing logic for the availability payload
* updated `MIN_Z2M_VERSION`. I'm open to discussion about this, if we don't do this I can also add back passlist availability checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed legacy availability passlist/blocklist support; availability now uses per-device configuration.

* **Compatibility**
  * Minimum Zigbee2MQTT requirement raised to v2.0.0; availability is derived from the provided configuration object.

* **Bug Fixes**
  * Improved device availability handling with a unified parser that accepts both legacy and new payload shapes.

* **Tests**
  * Removed legacy-list tests and added comprehensive coverage for multiple availability payload formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->