### PR TITLE
docs: update changelog with dropped support for Node.js v18 and older Homebridge versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Since version 1.0.0, we try to follow the [Semantic Versioning](https://semver.o
 
 ### Changed
 
+- Drop support for Node.js v18. Now requires Node.js v20.18.0+, v22.10.0+ or v24.0.0+.
+- Drop support for Homebridge v1.6.x and v1.7.x. Now requires Homebridge v1.8.0+ or v2.0.0-beta.0+.
 - Updated MQTT topic handling for Zigbee2MQTT 2.0 compatibility:
   - The `bridge/state` topic now supports both JSON format (`{"state":"online"}`) and plain strings for backwards compatibility
   - The deprecated `bridge/config` topic is no longer handled (use `bridge/info` instead)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Node.js requirement to v20.18.0+, v22.10.0+, or v24.0.0+
  * Updated minimum Homebridge requirement to v1.8.0+ or v2.0.0-beta.0+

<!-- end of auto-generated comment: release notes by coderabbit.ai -->