### PR TITLE
Air purifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Since version 1.0.0, we try to follow the [Semantic Versioning](https://semver.o
 
 ### Added
 
-- Add support for `fan` composite expose as AirPurifier service (Active, TargetAirPurifierState, RotationSpeed) and `replace_filter` expose as ContactSensor, enabling HomeKit support for devices like the IKEA STARKVIND E2007 air purifier.
+- Add support for `fan` composite expose as AirPurifier service (Active, CurrentAirPurifierState, TargetAirPurifierState, RotationSpeed) and `replace_filter` expose as ContactSensor, enabling HomeKit support for devices like the IKEA STARKVIND E2007 air purifier.
 
 ## [1.11.2] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Since version 1.0.0, we try to follow the [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard.
 
+## [Unreleased]
+
+### Added
+
+- Add support for `fan` composite expose as AirPurifier service (Active, TargetAirPurifierState, RotationSpeed) and `replace_filter` expose as ContactSensor, enabling HomeKit support for devices like the IKEA STARKVIND E2007 air purifier.
+
 ## [1.11.2] - 2026-04-09
 
 ### Fixed

--- a/docs/air_purifier.md
+++ b/docs/air_purifier.md
@@ -17,5 +17,5 @@ When switching Target Air Purifier State from Auto to Manual, the last known num
 
 ## Remarks
 
-* Exposes not mapped to HomeKit: `pm25`, `air_quality`, `led_enable`, `child_lock`, `filter_age`, `device_age`, `identify`.
+* Exposes not mapped to HomeKit: `air_quality`, `led_enable`, `child_lock`, `filter_age`, `identify`.
 * The `replace_filter` binary expose is created as a separate [Contact Sensor](https://developers.homebridge.io/#/service/ContactSensor) service, making it visible as a sensor trigger in HomeKit automations.

--- a/docs/air_purifier.md
+++ b/docs/air_purifier.md
@@ -1,0 +1,21 @@
+# Air Purifier
+If the device definition from Zigbee2MQTT contains one or more `exposes` entries of type `fan` that include a `state` feature, an [Air Purifier](https://developers.homebridge.io/#/service/AirPurifier) service will be created.
+The table below shows how the features within the `fan` composite expose and top-level exposes are mapped to characteristics.
+
+| Name | Type | Required access | Characteristic | Remarks |
+|-|-|-|-|-|
+| `state` (inside `fan`) | binary | published | [Active](https://developers.homebridge.io/#/characteristic/Active) + [Current Air Purifier State](https://developers.homebridge.io/#/characteristic/CurrentAirPurifierState) | **Required**. `ON` maps to Active/Purifying, `OFF` to Inactive |
+| `mode` (inside `fan`) | enum | published, set | [Target Air Purifier State](https://developers.homebridge.io/#/characteristic/TargetAirPurifierState) | `auto` maps to Auto, numeric values (`1`-`9`) map to Manual |
+| `fan_speed` (top-level) | numeric | published | [Rotation Speed](https://developers.homebridge.io/#/characteristic/RotationSpeed) | Read-only. Values 0–9 are scaled to 0–100%. Setting rotation speed via HomeKit sends a `fan_mode` command |
+| `replace_filter` (top-level) | binary | published | [Contact Sensor State](https://developers.homebridge.io/#/characteristic/ContactSensorState) (separate Contact Sensor service) | `true` (filter needs replacement) maps to Contact Not Detected; `false` maps to Contact Detected |
+
+## Setting fan speed from HomeKit
+
+Because `fan_speed` is a read-only reported value (the device reports the current speed), setting [Rotation Speed](https://developers.homebridge.io/#/characteristic/RotationSpeed) from HomeKit sends a `fan_mode` command with the corresponding numeric level (1–9). Setting Rotation Speed to 0 sends `fan_state: OFF`.
+
+When switching Target Air Purifier State from Auto to Manual, the last known numeric mode is restored.
+
+## Remarks
+
+* Exposes not mapped to HomeKit: `pm25`, `air_quality`, `led_enable`, `child_lock`, `filter_age`, `device_age`, `identify`.
+* The `replace_filter` binary expose is created as a separate [Contact Sensor](https://developers.homebridge.io/#/service/ContactSensor) service, making it visible as a sensor trigger in HomeKit automations.

--- a/src/converters/air_purifier.ts
+++ b/src/converters/air_purifier.ts
@@ -1,0 +1,218 @@
+import { Characteristic, CharacteristicSetCallback, CharacteristicValue } from 'homebridge';
+import { hap } from '../hap';
+import { getOrAddCharacteristic, setValidValuesOnCharacteristic } from '../helpers';
+import {
+  ExposesEntry,
+  ExposesEntryWithBinaryProperty,
+  ExposesEntryWithEnumProperty,
+  ExposesEntryWithFeatures,
+  ExposesKnownTypes,
+  exposesCanBeGet,
+  exposesHasBinaryProperty,
+  exposesHasEnumProperty,
+  exposesHasFeatures,
+} from '../z2mModels';
+import { BasicAccessory, ServiceCreator, ServiceHandler } from './interfaces';
+import { CharacteristicMonitor, MappingCharacteristicMonitor, NumericTransformCharacteristicMonitor } from './monitor';
+
+export class AirPurifierCreator implements ServiceCreator {
+  createServicesFromExposes(accessory: BasicAccessory, exposes: ExposesEntry[]): void {
+    exposes
+      .filter(
+        (e) =>
+          e.type === ExposesKnownTypes.FAN &&
+          exposesHasFeatures(e) &&
+          AirPurifierHandler.hasRequiredFeatures(e) &&
+          !accessory.isServiceHandlerIdKnown(AirPurifierHandler.generateIdentifier(e.endpoint))
+      )
+      .forEach((e) => {
+        try {
+          const handler = new AirPurifierHandler(e as ExposesEntryWithFeatures, accessory);
+          accessory.registerServiceHandler(handler);
+        } catch (error) {
+          accessory.log.warn(
+            `Failed to setup air purifier for accessory ${accessory.displayName} from expose "${JSON.stringify(e)}": ${error}`
+          );
+        }
+      });
+  }
+}
+
+class AirPurifierHandler implements ServiceHandler {
+  private static readonly NAME_STATE = 'state';
+  private static readonly NAME_MODE = 'mode';
+
+  public static hasRequiredFeatures(expose: ExposesEntry): boolean {
+    if (!exposesHasFeatures(expose)) {
+      return false;
+    }
+    const e = expose as ExposesEntryWithFeatures;
+    return e.features.some((f) => f.name === AirPurifierHandler.NAME_STATE && exposesHasBinaryProperty(f));
+  }
+
+  public mainCharacteristics: Characteristic[];
+
+  identifier: string;
+
+  private monitors: CharacteristicMonitor[] = [];
+  private stateExpose: ExposesEntryWithBinaryProperty;
+  private modeExpose?: ExposesEntryWithEnumProperty;
+  private numericModes: string[] = [];
+  private lastManualMode = '';
+
+  constructor(
+    expose: ExposesEntryWithFeatures,
+    private readonly accessory: BasicAccessory
+  ) {
+    const endpoint = expose.endpoint;
+    this.identifier = AirPurifierHandler.generateIdentifier(endpoint);
+
+    const stateFeature = expose.features.find((f) => f.name === AirPurifierHandler.NAME_STATE && exposesHasBinaryProperty(f));
+    if (stateFeature === undefined) {
+      throw new Error('fan state feature not found');
+    }
+    this.stateExpose = stateFeature as ExposesEntryWithBinaryProperty;
+
+    this.modeExpose = expose.features.find((f) => f.name === AirPurifierHandler.NAME_MODE && exposesHasEnumProperty(f)) as
+      | ExposesEntryWithEnumProperty
+      | undefined;
+
+    if (this.modeExpose !== undefined) {
+      this.numericModes = this.modeExpose.values.filter((v) => /^\d+$/.test(v)).sort((a, b) => Number(a) - Number(b));
+      this.lastManualMode = this.numericModes[0] ?? '';
+    }
+
+    const serviceName = accessory.getDefaultServiceDisplayName(endpoint);
+    accessory.log.debug(`Configuring AirPurifier for ${serviceName}`);
+    const service = accessory.getOrAddService(new hap.Service.AirPurifier(serviceName, endpoint));
+
+    // Active characteristic (fan on/off)
+    const activeChar = getOrAddCharacteristic(service, hap.Characteristic.Active).on('set', this.handleSetActive.bind(this));
+    this.mainCharacteristics = [activeChar];
+
+    const activeMapping = new Map<CharacteristicValue, CharacteristicValue>();
+    activeMapping.set(this.stateExpose.value_on, hap.Characteristic.Active.ACTIVE);
+    activeMapping.set(this.stateExpose.value_off, hap.Characteristic.Active.INACTIVE);
+    this.monitors.push(new MappingCharacteristicMonitor(this.stateExpose.property, service, hap.Characteristic.Active, activeMapping));
+
+    // CurrentAirPurifierState
+    const currentStateChar = getOrAddCharacteristic(service, hap.Characteristic.CurrentAirPurifierState);
+    setValidValuesOnCharacteristic(currentStateChar, [
+      hap.Characteristic.CurrentAirPurifierState.INACTIVE,
+      hap.Characteristic.CurrentAirPurifierState.PURIFYING_AIR,
+    ]);
+    const currentStateMapping = new Map<CharacteristicValue, CharacteristicValue>();
+    currentStateMapping.set(this.stateExpose.value_on, hap.Characteristic.CurrentAirPurifierState.PURIFYING_AIR);
+    currentStateMapping.set(this.stateExpose.value_off, hap.Characteristic.CurrentAirPurifierState.INACTIVE);
+    this.monitors.push(
+      new MappingCharacteristicMonitor(this.stateExpose.property, service, hap.Characteristic.CurrentAirPurifierState, currentStateMapping)
+    );
+
+    // TargetAirPurifierState and RotationSpeed: only when mode expose with numeric levels exists
+    if (this.modeExpose !== undefined) {
+      const targetStateChar = getOrAddCharacteristic(service, hap.Characteristic.TargetAirPurifierState).on(
+        'set',
+        this.handleSetTargetState.bind(this)
+      );
+      setValidValuesOnCharacteristic(targetStateChar, [
+        hap.Characteristic.TargetAirPurifierState.MANUAL,
+        hap.Characteristic.TargetAirPurifierState.AUTO,
+      ]);
+
+      const targetStateMapping = new Map<CharacteristicValue, CharacteristicValue>();
+      targetStateMapping.set('auto', hap.Characteristic.TargetAirPurifierState.AUTO);
+      for (const v of this.numericModes) {
+        targetStateMapping.set(v, hap.Characteristic.TargetAirPurifierState.MANUAL);
+      }
+      targetStateMapping.set('off', hap.Characteristic.TargetAirPurifierState.MANUAL);
+      this.monitors.push(
+        new MappingCharacteristicMonitor(this.modeExpose.property, service, hap.Characteristic.TargetAirPurifierState, targetStateMapping)
+      );
+
+      if (this.numericModes.length > 0) {
+        const numLevels = this.numericModes.length;
+        const rotationChar = getOrAddCharacteristic(service, hap.Characteristic.RotationSpeed).on(
+          'set',
+          this.handleSetRotationSpeed.bind(this)
+        );
+        rotationChar.setProps({ minValue: 0, maxValue: 100, minStep: Math.floor(100 / numLevels) });
+        // Monitor fan_mode for numeric values → rotation speed percentage
+        this.monitors.push(
+          new NumericTransformCharacteristicMonitor(this.modeExpose.property, service, hap.Characteristic.RotationSpeed, (value) => {
+            const idx = this.numericModes.indexOf(value as string);
+            return idx >= 0 ? Math.round(((idx + 1) * 100) / numLevels) : undefined;
+          })
+        );
+      }
+    }
+  }
+
+  get getableKeys(): string[] {
+    const keys: string[] = [];
+    if (exposesCanBeGet(this.stateExpose)) {
+      keys.push(this.stateExpose.property);
+    }
+    if (this.modeExpose !== undefined && exposesCanBeGet(this.modeExpose)) {
+      keys.push(this.modeExpose.property);
+    }
+    return keys;
+  }
+
+  updateState(state: Record<string, unknown>): void {
+    // Cache last known manual mode for TargetAirPurifierState=MANUAL set operations
+    if (this.modeExpose !== undefined) {
+      const modeValue = state[this.modeExpose.property];
+      if (typeof modeValue === 'string' && modeValue !== 'auto' && modeValue !== 'off') {
+        this.lastManualMode = modeValue;
+      }
+    }
+    this.monitors.forEach((m) => m.callback(state, this.accessory.log));
+  }
+
+  static generateIdentifier(endpoint: string | undefined) {
+    let identifier = hap.Service.AirPurifier.UUID;
+    if (endpoint !== undefined) {
+      identifier += '_' + endpoint.trim();
+    }
+    return identifier;
+  }
+
+  private handleSetActive(value: CharacteristicValue, callback: CharacteristicSetCallback): void {
+    const data = {};
+    data[this.stateExpose.property] = value === hap.Characteristic.Active.ACTIVE ? this.stateExpose.value_on : this.stateExpose.value_off;
+    this.accessory.queueDataForSetAction(data);
+    callback(null);
+  }
+
+  private handleSetTargetState(value: CharacteristicValue, callback: CharacteristicSetCallback): void {
+    if (this.modeExpose === undefined) {
+      callback(new Error('Mode not supported'));
+      return;
+    }
+    const data = {};
+    if (value === hap.Characteristic.TargetAirPurifierState.AUTO) {
+      data[this.modeExpose.property] = 'auto';
+    } else {
+      data[this.modeExpose.property] = this.lastManualMode;
+    }
+    this.accessory.queueDataForSetAction(data);
+    callback(null);
+  }
+
+  private handleSetRotationSpeed(value: CharacteristicValue, callback: CharacteristicSetCallback): void {
+    if (this.modeExpose === undefined || this.numericModes.length === 0) {
+      callback(new Error('Mode not supported'));
+      return;
+    }
+    const data = {};
+    const speed = value as number;
+    if (speed <= 0) {
+      data[this.stateExpose.property] = this.stateExpose.value_off;
+    } else {
+      const idx = Math.min(this.numericModes.length - 1, Math.max(0, Math.round((speed * this.numericModes.length) / 100) - 1));
+      data[this.modeExpose.property] = this.numericModes[idx];
+    }
+    this.accessory.queueDataForSetAction(data);
+    callback(null);
+  }
+}

--- a/src/converters/air_purifier.ts
+++ b/src/converters/air_purifier.ts
@@ -6,11 +6,13 @@ import {
   ExposesEntryWithBinaryProperty,
   ExposesEntryWithEnumProperty,
   ExposesEntryWithFeatures,
+  ExposesEntryWithNumericRangeProperty,
   ExposesKnownTypes,
   exposesCanBeGet,
   exposesHasBinaryProperty,
   exposesHasEnumProperty,
   exposesHasFeatures,
+  exposesHasNumericRangeProperty,
 } from '../z2mModels';
 import { BasicAccessory, ServiceCreator, ServiceHandler } from './interfaces';
 import { CharacteristicMonitor, MappingCharacteristicMonitor, NumericTransformCharacteristicMonitor } from './monitor';
@@ -27,7 +29,10 @@ export class AirPurifierCreator implements ServiceCreator {
       )
       .forEach((e) => {
         try {
-          const handler = new AirPurifierHandler(e as ExposesEntryWithFeatures, accessory);
+          const fanSpeedExpose = exposes.find((x) => x.name === 'fan_speed' && exposesHasNumericRangeProperty(x)) as
+            | ExposesEntryWithNumericRangeProperty
+            | undefined;
+          const handler = new AirPurifierHandler(e as ExposesEntryWithFeatures, accessory, fanSpeedExpose);
           accessory.registerServiceHandler(handler);
         } catch (error) {
           accessory.log.warn(
@@ -57,13 +62,16 @@ class AirPurifierHandler implements ServiceHandler {
   private monitors: CharacteristicMonitor[] = [];
   private stateExpose: ExposesEntryWithBinaryProperty;
   private modeExpose?: ExposesEntryWithEnumProperty;
+  private fanSpeedExpose?: ExposesEntryWithNumericRangeProperty;
   private numericModes: string[] = [];
   private lastManualMode = '';
 
   constructor(
     expose: ExposesEntryWithFeatures,
-    private readonly accessory: BasicAccessory
+    private readonly accessory: BasicAccessory,
+    fanSpeedExpose?: ExposesEntryWithNumericRangeProperty
   ) {
+    this.fanSpeedExpose = fanSpeedExpose;
     const endpoint = expose.endpoint;
     this.identifier = AirPurifierHandler.generateIdentifier(endpoint);
 
@@ -135,14 +143,23 @@ class AirPurifierHandler implements ServiceHandler {
           'set',
           this.handleSetRotationSpeed.bind(this)
         );
-        rotationChar.setProps({ minValue: 0, maxValue: 100, minStep: Math.floor(100 / numLevels) });
-        // Monitor fan_mode for numeric values → rotation speed percentage
+        rotationChar.setProps({ minValue: 0, maxValue: 100, minStep: 1 });
+        // Monitor fan_mode (SET echo) for numeric values → rotation speed percentage
         this.monitors.push(
           new NumericTransformCharacteristicMonitor(this.modeExpose.property, service, hap.Characteristic.RotationSpeed, (value) => {
             const idx = this.numericModes.indexOf(value as string);
             return idx >= 0 ? Math.round(((idx + 1) * 100) / numLevels) : undefined;
           })
         );
+        // Monitor fan_speed (published) → rotation speed percentage; covers auto mode
+        if (this.fanSpeedExpose !== undefined) {
+          const speedMax = this.fanSpeedExpose.value_max;
+          this.monitors.push(
+            new NumericTransformCharacteristicMonitor(this.fanSpeedExpose.property, service, hap.Characteristic.RotationSpeed, (value) =>
+              Math.round(((value as number) * 100) / speedMax)
+            )
+          );
+        }
       }
     }
   }
@@ -154,6 +171,9 @@ class AirPurifierHandler implements ServiceHandler {
     }
     if (this.modeExpose !== undefined && exposesCanBeGet(this.modeExpose)) {
       keys.push(this.modeExpose.property);
+    }
+    if (this.fanSpeedExpose !== undefined && exposesCanBeGet(this.fanSpeedExpose)) {
+      keys.push(this.fanSpeedExpose.property);
     }
     return keys;
   }

--- a/src/converters/air_purifier.ts
+++ b/src/converters/air_purifier.ts
@@ -29,9 +29,9 @@ export class AirPurifierCreator implements ServiceCreator {
       )
       .forEach((e) => {
         try {
-          const fanSpeedExpose = exposes.find((x) => x.name === 'fan_speed' && exposesHasNumericRangeProperty(x)) as
-            | ExposesEntryWithNumericRangeProperty
-            | undefined;
+          const fanSpeedExpose = exposes.find(
+            (x) => x.name === 'fan_speed' && exposesHasNumericRangeProperty(x) && x.endpoint === e.endpoint
+          ) as ExposesEntryWithNumericRangeProperty | undefined;
           const handler = new AirPurifierHandler(e as ExposesEntryWithFeatures, accessory, fanSpeedExpose);
           accessory.registerServiceHandler(handler);
         } catch (error) {

--- a/src/converters/basic_sensors.ts
+++ b/src/converters/basic_sensors.ts
@@ -21,6 +21,7 @@ import { LightSensorHandler } from './basic_sensors/light';
 import { MovingSensorHandler } from './basic_sensors/moving';
 import { OccupancySensorHandler } from './basic_sensors/occupancy';
 import { PresenceSensorHandler } from './basic_sensors/presence';
+import { ReplaceFilterSensorHandler } from './basic_sensors/replace_filter';
 import { SmokeSensorHandler } from './basic_sensors/smoke';
 import { TemperatureSensorHandler } from './basic_sensors/temperature';
 import { VibrationSensorHandler } from './basic_sensors/vibration';
@@ -61,6 +62,7 @@ export class BasicSensorCreator implements ServiceCreator {
     GasLeakSensorHandler,
     DeviceTemperatureSensorHandler,
     CarbonDioxideSensorHandler,
+    ReplaceFilterSensorHandler,
   ];
 
   private static configs: WithConfigurableConverter<unknown>[] = [OccupancySensorHandler];

--- a/src/converters/basic_sensors/replace_filter.ts
+++ b/src/converters/basic_sensors/replace_filter.ts
@@ -1,0 +1,32 @@
+import { hap } from '../../hap';
+import { ExposesEntryWithBinaryProperty, ExposesEntryWithProperty, ExposesKnownTypes } from '../../z2mModels';
+import { BasicAccessory } from '../interfaces';
+import { BinarySensorHandler } from './binary';
+
+export class ReplaceFilterSensorHandler extends BinarySensorHandler {
+  public static readonly exposesName: string = 'replace_filter';
+  public static readonly exposesType: ExposesKnownTypes = ExposesKnownTypes.BINARY;
+
+  constructor(expose: ExposesEntryWithProperty, otherExposes: ExposesEntryWithBinaryProperty[], accessory: BasicAccessory) {
+    super(
+      accessory,
+      expose as ExposesEntryWithBinaryProperty,
+      otherExposes,
+      ReplaceFilterSensorHandler.generateIdentifier,
+      'ReplaceFilterSensor',
+      (n, t) => new hap.Service.ContactSensor(n, t),
+      hap.Characteristic.ContactSensorState,
+      hap.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED,
+      hap.Characteristic.ContactSensorState.CONTACT_DETECTED,
+      'replace_filter'
+    );
+  }
+
+  static generateIdentifier(endpoint: string | undefined) {
+    let identifier = 'replace_filter_' + hap.Service.ContactSensor.UUID;
+    if (endpoint !== undefined) {
+      identifier += '_' + endpoint.trim();
+    }
+    return identifier;
+  }
+}

--- a/src/converters/creators.ts
+++ b/src/converters/creators.ts
@@ -1,6 +1,7 @@
 import { BasicLogger } from '../logger';
 import { ExposesEntry } from '../z2mModels';
 import { StatelessProgrammableSwitchCreator } from './action';
+import { AirPurifierCreator } from './air_purifier';
 import { AirQualitySensorCreator } from './air_quality';
 import { BasicSensorCreator } from './basic_sensors';
 import { BatteryCreator } from './battery';
@@ -35,6 +36,7 @@ export class BasicServiceCreatorManager
     ElectricalSensorCreator,
     StatelessProgrammableSwitchCreator,
     ThermostatCreator,
+    AirPurifierCreator,
     BatteryCreator,
   ];
 

--- a/src/converters/monitor.ts
+++ b/src/converters/monitor.ts
@@ -76,6 +76,21 @@ export class PassthroughCharacteristicMonitor extends BaseCharacteristicMonitor 
   }
 }
 
+export class NumericTransformCharacteristicMonitor extends BaseCharacteristicMonitor {
+  constructor(
+    key: string,
+    service: Service,
+    characteristic: string | WithUUID<new () => Characteristic>,
+    private readonly transformer: MqttToHomeKitValueTransformer
+  ) {
+    super(key, service, characteristic);
+  }
+
+  transformValueFromMqtt(value: unknown): CharacteristicValue | undefined {
+    return this.transformer(value);
+  }
+}
+
 export class MappingCharacteristicMonitor extends BaseCharacteristicMonitor {
   constructor(
     key: string,

--- a/test/air_purifier.spec.ts
+++ b/test/air_purifier.spec.ts
@@ -72,6 +72,16 @@ describe('Air Purifier', () => {
       );
     });
 
+    test('Status update: fan_mode "off" → TargetAirPurifierState=MANUAL', () => {
+      expect(harness).toBeDefined();
+      harness.checkSingleUpdateState(
+        '{"fan_mode":"off"}',
+        hap.Service.AirPurifier,
+        hap.Characteristic.TargetAirPurifierState,
+        hap.Characteristic.TargetAirPurifierState.MANUAL
+      );
+    });
+
     test('Status update: fan_mode "1" → TargetAirPurifierState=MANUAL + RotationSpeed=11', () => {
       expect(harness).toBeDefined();
       const expected = new Map();

--- a/test/air_purifier.spec.ts
+++ b/test/air_purifier.spec.ts
@@ -158,5 +158,25 @@ describe('Air Purifier', () => {
       expect(harness).toBeDefined();
       harness.checkHomeKitUpdate(hap.Service.AirPurifier, 'fan_mode_speed', 50, { fan_mode: '5' });
     });
+
+    test('Status update: fan_speed 9 → RotationSpeed=100', () => {
+      expect(harness).toBeDefined();
+      harness.checkSingleUpdateState('{"fan_speed":9}', hap.Service.AirPurifier, hap.Characteristic.RotationSpeed, 100);
+    });
+
+    test('Status update: fan_speed 1 → RotationSpeed=11', () => {
+      expect(harness).toBeDefined();
+      harness.checkSingleUpdateState('{"fan_speed":1}', hap.Service.AirPurifier, hap.Characteristic.RotationSpeed, 11);
+    });
+
+    test('Status update: fan_speed 5 → RotationSpeed=56', () => {
+      expect(harness).toBeDefined();
+      harness.checkSingleUpdateState('{"fan_speed":5}', hap.Service.AirPurifier, hap.Characteristic.RotationSpeed, 56);
+    });
+
+    test('Status update: fan_speed 0 → RotationSpeed=0', () => {
+      expect(harness).toBeDefined();
+      harness.checkSingleUpdateState('{"fan_speed":0}', hap.Service.AirPurifier, hap.Characteristic.RotationSpeed, 0);
+    });
   });
 });

--- a/test/air_purifier.spec.ts
+++ b/test/air_purifier.spec.ts
@@ -1,0 +1,162 @@
+import * as hapNodeJs from '@homebridge/hap-nodejs';
+import { vi } from 'vitest';
+import { hap, setHap } from '../src/hap';
+import { ExposesEntry } from '../src/z2mModels';
+import { loadExposesFromFile, ServiceHandlersTestHarness } from './testHelpers';
+
+describe('Air Purifier', () => {
+  beforeAll(() => {
+    setHap(hapNodeJs);
+  });
+
+  describe('IKEA STARKVIND E2007', () => {
+    let deviceExposes: ExposesEntry[] = [];
+    let harness: ServiceHandlersTestHarness;
+
+    beforeEach(() => {
+      if (deviceExposes.length === 0 && harness === undefined) {
+        deviceExposes = loadExposesFromFile('ikea/e2007.json');
+        expect(deviceExposes.length).toBeGreaterThan(0);
+        const newHarness = new ServiceHandlersTestHarness();
+
+        // AirPurifier service
+        newHarness
+          .getOrAddHandler(hap.Service.AirPurifier)
+          .addExpectedCharacteristic('fan_state', hap.Characteristic.Active, true)
+          .addExpectedCharacteristic('fan_state_current', hap.Characteristic.CurrentAirPurifierState, false, 'fan_state')
+          .addExpectedCharacteristic('fan_mode', hap.Characteristic.TargetAirPurifierState, true)
+          .addExpectedCharacteristic('fan_mode_speed', hap.Characteristic.RotationSpeed, true, 'fan_mode');
+
+        // ContactSensor for replace_filter (custom identifier matches ReplaceFilterSensorHandler.generateIdentifier)
+        newHarness
+          .getOrAddHandler(hap.Service.ContactSensor, 'replace_filter', 'replace_filter_' + hap.Service.ContactSensor.UUID)
+          .addExpectedCharacteristic('replace_filter', hap.Characteristic.ContactSensorState);
+
+        newHarness.prepareCreationMocks();
+        newHarness.callCreators(deviceExposes);
+        newHarness.checkCreationExpectations();
+        newHarness.checkHasMainCharacteristics();
+        newHarness.checkExpectedGetableKeys(['fan_state']);
+        harness = newHarness;
+      }
+      harness?.clearMocks();
+    });
+
+    afterEach(() => {
+      vi.resetAllMocks();
+    });
+
+    test('Status update: fan ON → Active=ACTIVE + CurrentAirPurifierState=PURIFYING_AIR', () => {
+      expect(harness).toBeDefined();
+      const expectedUpdates = new Map<typeof hap.Characteristic.Active | typeof hap.Characteristic.CurrentAirPurifierState, number>();
+      expectedUpdates.set(hap.Characteristic.Active, hap.Characteristic.Active.ACTIVE);
+      expectedUpdates.set(hap.Characteristic.CurrentAirPurifierState, hap.Characteristic.CurrentAirPurifierState.PURIFYING_AIR);
+      harness.checkUpdateState('{"fan_state":"ON"}', hap.Service.AirPurifier, expectedUpdates);
+    });
+
+    test('Status update: fan OFF → Active=INACTIVE + CurrentAirPurifierState=INACTIVE', () => {
+      expect(harness).toBeDefined();
+      const expectedUpdates = new Map<typeof hap.Characteristic.Active | typeof hap.Characteristic.CurrentAirPurifierState, number>();
+      expectedUpdates.set(hap.Characteristic.Active, hap.Characteristic.Active.INACTIVE);
+      expectedUpdates.set(hap.Characteristic.CurrentAirPurifierState, hap.Characteristic.CurrentAirPurifierState.INACTIVE);
+      harness.checkUpdateState('{"fan_state":"OFF"}', hap.Service.AirPurifier, expectedUpdates);
+    });
+
+    test('Status update: fan_mode "auto" → TargetAirPurifierState=AUTO', () => {
+      expect(harness).toBeDefined();
+      harness.checkSingleUpdateState(
+        '{"fan_mode":"auto"}',
+        hap.Service.AirPurifier,
+        hap.Characteristic.TargetAirPurifierState,
+        hap.Characteristic.TargetAirPurifierState.AUTO
+      );
+    });
+
+    test('Status update: fan_mode "1" → TargetAirPurifierState=MANUAL + RotationSpeed=11', () => {
+      expect(harness).toBeDefined();
+      const expected = new Map();
+      expected.set(hap.Characteristic.TargetAirPurifierState, hap.Characteristic.TargetAirPurifierState.MANUAL);
+      expected.set(hap.Characteristic.RotationSpeed, 11);
+      harness.checkUpdateState('{"fan_mode":"1"}', hap.Service.AirPurifier, expected);
+    });
+
+    test('Status update: fan_mode "9" → TargetAirPurifierState=MANUAL + RotationSpeed=100', () => {
+      expect(harness).toBeDefined();
+      const expected = new Map();
+      expected.set(hap.Characteristic.TargetAirPurifierState, hap.Characteristic.TargetAirPurifierState.MANUAL);
+      expected.set(hap.Characteristic.RotationSpeed, 100);
+      harness.checkUpdateState('{"fan_mode":"9"}', hap.Service.AirPurifier, expected);
+    });
+
+    test('Status update: fan_mode "5" → TargetAirPurifierState=MANUAL + RotationSpeed=56', () => {
+      expect(harness).toBeDefined();
+      const expected = new Map();
+      expected.set(hap.Characteristic.TargetAirPurifierState, hap.Characteristic.TargetAirPurifierState.MANUAL);
+      expected.set(hap.Characteristic.RotationSpeed, 56);
+      harness.checkUpdateState('{"fan_mode":"5"}', hap.Service.AirPurifier, expected);
+    });
+
+    test('Status update: replace_filter true → ContactSensorState=CONTACT_NOT_DETECTED', () => {
+      expect(harness).toBeDefined();
+      harness.checkSingleUpdateState(
+        '{"replace_filter":true}',
+        'replace_filter_' + hap.Service.ContactSensor.UUID,
+        hap.Characteristic.ContactSensorState,
+        hap.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED
+      );
+    });
+
+    test('Status update: replace_filter false → ContactSensorState=CONTACT_DETECTED', () => {
+      expect(harness).toBeDefined();
+      harness.checkSingleUpdateState(
+        '{"replace_filter":false}',
+        'replace_filter_' + hap.Service.ContactSensor.UUID,
+        hap.Characteristic.ContactSensorState,
+        hap.Characteristic.ContactSensorState.CONTACT_DETECTED
+      );
+    });
+
+    test('HomeKit: Set Active=ACTIVE → fan_state ON', () => {
+      expect(harness).toBeDefined();
+      harness.checkHomeKitUpdateWithSingleValue(hap.Service.AirPurifier, 'fan_state', hap.Characteristic.Active.ACTIVE, 'ON');
+    });
+
+    test('HomeKit: Set Active=INACTIVE → fan_state OFF', () => {
+      expect(harness).toBeDefined();
+      harness.checkHomeKitUpdateWithSingleValue(hap.Service.AirPurifier, 'fan_state', hap.Characteristic.Active.INACTIVE, 'OFF');
+    });
+
+    test('HomeKit: Set TargetAirPurifierState=AUTO → fan_mode auto', () => {
+      expect(harness).toBeDefined();
+      harness.checkHomeKitUpdateWithSingleValue(
+        hap.Service.AirPurifier,
+        'fan_mode',
+        hap.Characteristic.TargetAirPurifierState.AUTO,
+        'auto'
+      );
+    });
+
+    test('HomeKit: Set TargetAirPurifierState=MANUAL → restores last known numeric mode', () => {
+      expect(harness).toBeDefined();
+      // Seed lastManualMode by sending a state update with a known numeric mode
+      harness.getOrAddHandler(hap.Service.AirPurifier).serviceHandler?.updateState({ fan_mode: '3' });
+      harness.clearMocks();
+      harness.checkHomeKitUpdateWithSingleValue(hap.Service.AirPurifier, 'fan_mode', hap.Characteristic.TargetAirPurifierState.MANUAL, '3');
+    });
+
+    test('HomeKit: Set RotationSpeed=0 → fan_state OFF', () => {
+      expect(harness).toBeDefined();
+      harness.checkHomeKitUpdate(hap.Service.AirPurifier, 'fan_mode_speed', 0, { fan_state: 'OFF' });
+    });
+
+    test('HomeKit: Set RotationSpeed=100 → fan_mode "9"', () => {
+      expect(harness).toBeDefined();
+      harness.checkHomeKitUpdate(hap.Service.AirPurifier, 'fan_mode_speed', 100, { fan_mode: '9' });
+    });
+
+    test('HomeKit: Set RotationSpeed=50 → fan_mode "5"', () => {
+      expect(harness).toBeDefined();
+      harness.checkHomeKitUpdate(hap.Service.AirPurifier, 'fan_mode_speed', 50, { fan_mode: '5' });
+    });
+  });
+});

--- a/test/exposes/ikea/e2007.json
+++ b/test/exposes/ikea/e2007.json
@@ -1,0 +1,104 @@
+[
+  {
+    "type": "fan",
+    "name": "fan",
+    "label": "Fan",
+    "features": [
+      {
+        "name": "state",
+        "label": "State",
+        "access": 7,
+        "type": "binary",
+        "property": "fan_state",
+        "description": "On/off state of the fan",
+        "value_on": "ON",
+        "value_off": "OFF"
+      },
+      {
+        "name": "mode",
+        "label": "Mode",
+        "access": 2,
+        "type": "enum",
+        "property": "fan_mode",
+        "description": "Operating mode",
+        "values": ["off", "auto", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+      }
+    ]
+  },
+  {
+    "name": "fan_speed",
+    "label": "Fan speed",
+    "access": 1,
+    "type": "numeric",
+    "property": "fan_speed",
+    "description": "Current fan speed (read-only)",
+    "value_min": 0,
+    "value_max": 9
+  },
+  {
+    "name": "pm25",
+    "label": "PM2.5",
+    "access": 1,
+    "type": "numeric",
+    "property": "pm25",
+    "description": "Particulate matter 2.5 density",
+    "unit": "µg/m³"
+  },
+  {
+    "name": "air_quality",
+    "label": "Air quality",
+    "access": 1,
+    "type": "enum",
+    "property": "air_quality",
+    "description": "Air quality index",
+    "values": ["excellent", "good", "moderate", "poor", "unhealthy", "hazardous", "out_of_range", "unknown"]
+  },
+  {
+    "name": "replace_filter",
+    "label": "Replace filter",
+    "access": 1,
+    "type": "binary",
+    "property": "replace_filter",
+    "description": "Indicates whether the filter needs to be replaced",
+    "value_on": true,
+    "value_off": false
+  },
+  {
+    "name": "filter_age",
+    "label": "Filter age",
+    "access": 1,
+    "type": "numeric",
+    "property": "filter_age",
+    "description": "Age of the filter in minutes",
+    "unit": "min"
+  },
+  {
+    "name": "child_lock",
+    "label": "Child lock",
+    "access": 7,
+    "type": "binary",
+    "property": "child_lock",
+    "description": "Activate/deactivate child lock",
+    "value_on": "LOCK",
+    "value_off": "UNLOCK"
+  },
+  {
+    "name": "led_enable",
+    "label": "LED enable",
+    "access": 7,
+    "type": "binary",
+    "property": "led_enable",
+    "description": "Turn on/off the LED",
+    "value_on": true,
+    "value_off": false
+  },
+  {
+    "name": "identify",
+    "label": "Identify",
+    "access": 2,
+    "type": "enum",
+    "property": "identify",
+    "description": "Trigger identification",
+    "values": ["identify"]
+  }
+]


### PR DESCRIPTION
Add support for Air purifiers. 
User can set power, turn off, set on auto, and get notified when the filter needs changing. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HomeKit support for air purifiers: power, Auto/Manual mode, and fan speed exposed as an Air Purifier service; 0% fan speed turns the device off.
  * Filter replacement status exposed as a separate Contact Sensor for filter reminders and automations.
* **Documentation**
  * Added user-facing docs describing when services appear and how modes/speeds map between device and HomeKit.
* **Tests**
  * Added test coverage validating device↔HomeKit state and write mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->