### PR TITLE
Support alarm_1 fallback for vibration sensors

### DIFF
--- a/src/converters/basic_sensors/vibration.ts
+++ b/src/converters/basic_sensors/vibration.ts
@@ -5,6 +5,7 @@ import { BinarySensorHandler } from './binary';
 
 export class VibrationSensorHandler extends BinarySensorHandler {
   public static readonly exposesName: string = 'vibration';
+  public static readonly fallbackExposesNames: string[] = ['alarm_1'];
 
   constructor(expose: ExposesEntryWithProperty, otherExposes: ExposesEntryWithBinaryProperty[], accessory: BasicAccessory) {
     super(

--- a/test/basic_sensors.spec.ts
+++ b/test/basic_sensors.spec.ts
@@ -581,6 +581,30 @@ describe('Basic Sensors', () => {
       harness.clearMocks();
       harness.checkSingleUpdateState('{"vibration":true}', vibrationSensorId, hap.Characteristic.MotionDetected, true);
     });
+
+    test('Create and update vibration from alarm_1 fallback expose', (): void => {
+      const fallbackExposes = loadExposesFromFile('heiman/hs1vs-n.json').map((entry) =>
+        entry.name === 'vibration' ? { ...entry, name: 'alarm_1', property: 'alarm_1' } : entry
+      );
+      const fallbackHarness = new ServiceHandlersTestHarness();
+
+      fallbackHarness
+        .getOrAddHandler(hap.Service.MotionSensor, 'vibration', vibrationSensorId)
+        .addExpectedCharacteristic('alarm_1', hap.Characteristic.MotionDetected)
+        .addExpectedCharacteristic('battery_low', hap.Characteristic.StatusLowBattery)
+        .addExpectedCharacteristic('tamper', hap.Characteristic.StatusTampered);
+      fallbackHarness.prepareCreationMocks();
+
+      fallbackHarness.callCreators(fallbackExposes);
+
+      fallbackHarness.checkCreationExpectations();
+      fallbackHarness.checkHasMainCharacteristics();
+      fallbackHarness.checkExpectedGetableKeys([]);
+      fallbackHarness.clearMocks();
+      fallbackHarness.checkSingleUpdateState('{"alarm_1":true}', vibrationSensorId, hap.Characteristic.MotionDetected, true);
+      fallbackHarness.clearMocks();
+      fallbackHarness.checkSingleUpdateState('{"alarm_1":false}', vibrationSensorId, hap.Characteristic.MotionDetected, false);
+    });
   });
 
   describe('SmartThings STSS-PRES-001', () => {


### PR DESCRIPTION
# PR Draft: Support `alarm_1` fallback for vibration sensors

Target issue: https://github.com/itavero/homebridge-z2m/issues/1228

## Title

Support `alarm_1` fallback for vibration sensors

## Summary

- add `alarm_1` as a fallback expose name for `VibrationSensorHandler`
- keep the existing `vibration` identifier path for backwards compatibility
- add a regression test proving `alarm_1` still creates and updates the Motion Sensor

## Why

Issue `#1228` reports that the Third Reality `3RVS01031Z` vibration sensor is re-exposed by Zigbee2MQTT 2.12.x as `alarm_1` instead of `vibration`. The current handler matches only `vibration`, so the plugin never instantiates the motion sensor handler and HomeKit only gets Battery.

This patch accepts `alarm_1` as a fallback match while preserving the existing `vibration` identifier path for older devices and cached accessories.

## Verification

```bash
npm install
npm exec -- vitest run test/basic_sensors.spec.ts
npm exec -- biome check src/converters/basic_sensors/vibration.ts test/basic_sensors.spec.ts
npm run build
git diff --check
```

Observed:

- `vitest`: `17 passed`
- `biome check`: pass
- `build`: pass
- `git diff --check`: pass

## Scope Notes

- This patch only broadens expose-name matching for vibration sensors.
- It does not change unrelated binary sensors, Zigbee2MQTT device definitions, or HomeKit service mapping outside the vibration path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vibration sensor devices now also recognize an alternate alarm signal name, improving compatibility with devices that report vibration status differently.
  * Added coverage to ensure vibration state updates are correctly reflected when the alternate signal is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->