### PR TITLE
Add support for soil_moisture in TS0601_soil_3

### DIFF
--- a/src/converters/basic_sensors/humidity.ts
+++ b/src/converters/basic_sensors/humidity.ts
@@ -8,6 +8,7 @@ import { BasicSensorHandler } from './basic';
 
 export class HumiditySensorHandler extends BasicSensorHandler {
   public static readonly exposesName: string = 'humidity';
+  public static readonly fallbackExposesNames: string[] = ['soil_moisture'];
   public static readonly exposesType: ExposesKnownTypes = ExposesKnownTypes.NUMERIC;
 
   public readonly mainCharacteristics: Characteristic[] = [];

--- a/test/basic_sensors.spec.ts
+++ b/test/basic_sensors.spec.ts
@@ -10,6 +10,32 @@ describe('Basic Sensors', () => {
     setHap(hapNodeJs);
   });
 
+  test('Tuya soil moisture sensor', (): void => {
+    const deviceExposes: ExposesEntry[] = [
+      {
+        type: 'numeric',
+        name: 'soil_moisture',
+        property: 'soil_moisture',
+        access: 1,
+        unit: '%',
+        value_min: 0,
+        value_max: 100,
+      },
+    ];
+    const harness = new ServiceHandlersTestHarness();
+
+    harness
+      .getOrAddHandler(hap.Service.HumiditySensor)
+      .addExpectedCharacteristic('soil_moisture', hap.Characteristic.CurrentRelativeHumidity);
+    harness.prepareCreationMocks();
+    harness.callCreators(deviceExposes);
+    harness.checkCreationExpectations();
+    harness.checkHasMainCharacteristics();
+
+    harness.clearMocks();
+    harness.checkSingleUpdateState('{"soil_moisture":42}', hap.Service.HumiditySensor, hap.Characteristic.CurrentRelativeHumidity, 42);
+  });
+
   describe('Aqara T1 temperature, humidity and pressure sensor', () => {
     // Shared "state"
     const airPressureServiceId = 'E863F00A-079E-48FF-8F27-9C2605A29F52';


### PR DESCRIPTION
TS0601_soil_3 exports only temperature data which is useless as this is soil moisture sensor. This patch add soil_moisture so it is visible properly in homekit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing soil moisture readings as humidity data.
  * Soil moisture sensor values are now mapped to the current relative humidity measurement.

* **Tests**
  * Added coverage validating soil moisture sensor creation and value updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->